### PR TITLE
fix: run init script a little bit later on Android

### DIFF
--- a/templates/platforms/android-studio/app/src/main/kotlin/_domain_/_projectname_/RustWebChromeClient.kt.hbs
+++ b/templates/platforms/android-studio/app/src/main/kotlin/_domain_/_projectname_/RustWebChromeClient.kt.hbs
@@ -10,7 +10,7 @@ class RustWebChromeClient: WebChromeClient() {
     if (url.endsWith("##")) {
       url = url.dropLast(2)
     }
-    if (loadedUrl != url) {
+    if (loadedUrl != url && progress >= 50) {
       loadedUrl = url
       runInitializationScripts()
     }

--- a/templates/platforms/android-studio/app/src/main/kotlin/_domain_/_projectname_/RustWebChromeClient.kt.hbs
+++ b/templates/platforms/android-studio/app/src/main/kotlin/_domain_/_projectname_/RustWebChromeClient.kt.hbs
@@ -10,7 +10,7 @@ class RustWebChromeClient: WebChromeClient() {
     if (url.endsWith("##")) {
       url = url.dropLast(2)
     }
-    if (loadedUrl != url && progress >= 50) {
+    if (loadedUrl != url && progress >= 20) {
       loadedUrl = url
       runInitializationScripts()
     }


### PR DESCRIPTION
I found a race condition on the initialization script for dev servers where it is running too soon and the webview is ignoring the script. Changing it to run when progress >= 50 fixed it, but we should watch it.