### PR TITLE
refactor(android/run): change default activity to `.MainActivity`

### DIFF
--- a/src/android/cli.rs
+++ b/src/android/cli.rs
@@ -73,7 +73,7 @@ pub enum Command {
         #[structopt(
             short = "a",
             long = "activity",
-            default_value = "android.app.NativeActivity",
+            default_value = ".MainActivity",
             help = "Specifies which activtiy to launch"
         )]
         activity: String,


### PR DESCRIPTION
`.MainActivity` is the default activity name in all android projects and since our tempalate now uses that name, it makes sense to make it the default. It makes it easier to just do `cargo android run`