### PR TITLE
chore: update ios template to latest wry version

### DIFF
--- a/src/apple/config/mod.rs
+++ b/src/apple/config/mod.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 static DEFAULT_PROJECT_DIR: &str = "gen/apple";
 const DEFAULT_BUNDLE_VERSION: VersionNumber = VersionNumber::new(VersionTriple::new(1, 0, 0), None);
-const DEFAULT_IOS_VERSION: VersionDouble = VersionDouble::new(9, 0);
+const DEFAULT_IOS_VERSION: VersionDouble = VersionDouble::new(11, 0);
 const DEFAULT_MACOS_VERSION: VersionDouble = VersionDouble::new(11, 0);
 
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/templates/apps/wry/src/lib.rs.hbs
+++ b/templates/apps/wry/src/lib.rs.hbs
@@ -11,7 +11,7 @@ use wry::{
         event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
         window::WindowBuilder, event::{Event, StartCause},
     },
-    http::ResponseBuilder,
+    http::{header::CONTENT_TYPE, Response},
     webview::{WebViewBuilder, WebView},
 };
 
@@ -86,7 +86,7 @@ fn main() -> Result<()> {
             #[cfg(not(target_os = "android"))]
             {
                 // Remove url scheme
-                let path = request.uri().replace("wry://", "");
+                let path = request.uri().path();
                 let mut resource = core_foundation::bundle::CFBundle::main_bundle()
                     .resources_path()
                     .unwrap();
@@ -107,12 +107,12 @@ fn main() -> Result<()> {
                     unimplemented!();
                 };
 
-                ResponseBuilder::new().mimetype(meta).body(data)
+                Ok(Response::builder().header(CONTENT_TYPE, meta).body(data)?)
             }
 
             #[cfg(target_os = "android")]
             {
-                ResponseBuilder::new().body(vec![])
+                Ok(Response::builder().body(vec![])?)
             }
         })
         .build()?;


### PR DESCRIPTION
There's another issue I haven't solved which is iphone 14's arch will be `unkarch` in `ios-deploy`.
But it could just deploy with xcode, I'll look into that in the future.