### PR TITLE
Fix for cargo android list not identifying devices connected through …

### DIFF
--- a/src/android/adb/device_list.rs
+++ b/src/android/adb/device_list.rs
@@ -35,7 +35,7 @@ impl Reportable for Error {
     }
 }
 
-const ADB_DEVICE_REGEX: &str = r"^([\S]{6,22})	device\b";
+const ADB_DEVICE_REGEX: &str = r"^([\S]{6,100})	device\b";
 
 pub fn device_list(env: &Env) -> Result<BTreeSet<Device<'static>>, Error> {
     super::check_authorized(


### PR DESCRIPTION
When listing attached debugging devices using `cargo android list`, devices with a name longer than 22 characters are not listed. Using `adb devices` correctly shows all the attached devices.

This seems to primarily affect devices connected through wifi, as their name tends to be longer.

Galaxy S10 connected through WiFi:
```
┌─🦝─[/home/jorge/js_projects/tauri-mobile-test]
└─ cargo android list
  -- none --
┌─🦝─[/home/jorge/js_projects/tauri-mobile-test]
└─ adb devices
List of devices attached
adb-R38M10J2LWT-fqNLtq._adb-tls-connect._tcp    device
```

Galaxy S10 connected through USB:
```
┌─🦝─[/home/jorge/js_projects/tauri-mobile-test]
└─ cargo android list
  [0] Jorge's S10 (SM-G973U1)
┌─🦝─[/home/jorge/js_projects/tauri-mobile-test]
└─ adb devices
List of devices attached
R38M10J2LWT     device
```

Changing the regex expression to detect devices with a name of up to 100 characters seems to fix the issue.
```
┌─🦝─[/home/jorge/js_projects/tauri-mobile-test]
└─ cargo android list
  [0] Jorge's S10 (SM-G973U1)
┌─🦝─[/home/jorge/js_projects/tauri-mobile-test]
└─ adb devices
List of devices attached
adb-R38M10J2LWT-fqNLtq._adb-tls-connect._tcp    device
```
