### PR TITLE
fix(template): custom protocol return type should be Cow, closes #60

### DIFF
--- a/templates/apps/wry/src/lib.rs.hbs
+++ b/templates/apps/wry/src/lib.rs.hbs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
                     unimplemented!();
                 };
 
-                Ok(Response::builder().header(CONTENT_TYPE, meta).body(data)?)
+                Ok(Response::builder().header(CONTENT_TYPE, meta).body(data.into())?)
             }
 
             #[cfg(target_os = "android")]


### PR DESCRIPTION
In wry's latest `dev` branch, PR https://github.com/tauri-apps/wry/issues/796 changed return type of `custom_protocol`.

Here we need to convert `data` from `Vec<u8>` into `Cow<'static, [u8]>`

closes #60