### PR TITLE
feat: allow setting a custom target dir resolver

### DIFF
--- a/.changes/target-dir-resolver.md
+++ b/.changes/target-dir-resolver.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Allow specifying an app target dir resolver via `config::App::with_target_dir_resolver`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-mobile"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cocoa",
  "colored",

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -306,12 +306,11 @@ impl<'a> Target<'a> {
         let jnilibs =
             JniLibs::create(config, *self).map_err(SymlinkLibsError::JniLibsCreationFailed)?;
 
-        let src = config.app().prefix_path(format!(
-            "target/{}/{}/{}",
-            &self.triple,
-            profile.as_str(),
-            config.so_name(),
-        ));
+        let src = config
+            .app()
+            .target_dir(&self.triple, profile)
+            .join(config.so_name());
+
         jnilibs
             .symlink_lib(&src)
             .map_err(SymlinkLibsError::SymlinkFailed)?;

--- a/src/apple/ios_deploy/mod.rs
+++ b/src/apple/ios_deploy/mod.rs
@@ -22,12 +22,14 @@ struct DeviceInfo {
 #[serde(tag = "Event")]
 enum Event {
     #[serde(rename_all = "PascalCase")]
+    #[allow(dead_code)]
     BundleCopy {
         percent: u32,
         overall_percent: u32,
         path: PathBuf,
     },
     #[serde(rename_all = "PascalCase")]
+    #[allow(dead_code)]
     BundleInstall {
         percent: u32,
         overall_percent: u32,
@@ -36,6 +38,7 @@ enum Event {
     #[serde(rename_all = "PascalCase")]
     DeviceDetected { device: DeviceInfo },
     #[serde(rename_all = "PascalCase")]
+    #[allow(dead_code)]
     Error { code: u32, status: String },
     #[serde(other)]
     Unknown,


### PR DESCRIPTION
This is needed for https://github.com/tauri-apps/tauri/issues/5865. The ideal solution would be moving the target dir resolver from the Tauri CLI to a separate crate, but that's overengineering until someone wants to use the tauri-mobile CLI without Tauri.