### PR TITLE
fix(template): fix variable assignment in wry's ios template, close #81

### DIFF
--- a/.changes/template-ios-wry-content-return.md
+++ b/.changes/template-ios-wry-content-return.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Fix content assignment in ios template.

--- a/templates/apps/wry/src/lib.rs.hbs
+++ b/templates/apps/wry/src/lib.rs.hbs
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
                         .resources_path()
                         .unwrap()
                         .join(&path);
-                    read(canonicalize(&path)?)?;
+                    read(canonicalize(&path)?)?
                 };
 
                 // Return asset contents and mime types based on file extentions


### PR DESCRIPTION
`content` was assigned to `()` in iOS. This makes `data` in line 123 become `()` and cannot be converted to `Cow`.