### PR TITLE
fix: enable cli feature when cargo mobile update, closes #84

### DIFF
--- a/.changes/fix-cargo-mobile-update.md
+++ b/.changes/fix-cargo-mobile-update.md
@@ -1,0 +1,5 @@
+---
+'tauri-mobile': patch
+---
+
+Fix `cargo mobile update` target branch and enabled `cli` feature when update.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-mobile"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "cocoa",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ categories = [ "development-tools::cargo-plugins" ]
 license = "Apache-2.0 OR MIT"
 
 [[bin]]
+name = "cargo-mobile"
+required-features = [ "cli" ]
+
+[[bin]]
 name = "cargo-apple"
 required-features = [ "cli" ]
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -16,6 +16,7 @@ use std::{
 static ENABLED_FEATURES: &[&str] = &[
     #[cfg(feature = "brainium")]
     "brainium",
+    "cli",
 ];
 
 #[derive(Debug)]

--- a/src/util/git/repo.rs
+++ b/src/util/git/repo.rs
@@ -157,7 +157,7 @@ impl Repo {
                 .run_and_wait()
                 .map_err(Error::FetchFailed)?;
             self.git()
-                .command_parse("reset --hard origin/master")
+                .command_parse("reset --hard origin/dev")
                 .run_and_wait()
                 .map_err(Error::ResetFailed)?;
             self.git()


### PR DESCRIPTION
cargo-mobile requires the `cli` feature to be enabled.

The `cli` is a default feature, so it will be built when `cargo install` execute.

When `cargo mobile update`, cargo-mobile will install binary again with `cargo install --no-default-features`; hence `cli` was not built at the moment. 

*Need to manually update tauri-mobile again to apply this patch to make the update command works