### PR TITLE
feat: add support for android studio which installed by jetbrains toolbox

### DIFF
--- a/.changes/Added_support_for_opening_Android_Studio.md
+++ b/.changes/Added_support_for_opening_Android_Studio.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Added support for opening Android Studio installed by JetBrains Toolbox

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "embed-resource"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-mobile"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cocoa",
  "colored",
@@ -1121,6 +1127,7 @@ dependencies = [
  "thiserror",
  "toml",
  "ureq",
+ "which",
  "winapi",
  "windows",
 ]
@@ -1436,6 +1443,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ textwrap = { version = "0.11.0", features = [ "term_size" ] }
 thiserror = "1.0.20"
 toml = { version = "0.5.6", features = [ "preserve_order" ] }
 os_pipe = "1"
+which = "4.4.0"
 
 [dev-dependencies]
 rstest = "0.12"


### PR DESCRIPTION
The android studio which installed by jetbrains toolbox will not have the `"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Android Studio\\UninstallString"` in the registry, but Jetbrain Toolbox will auto generate a `studio.cmd` for Android Studio, so we can use it to launch Android Studio for toolbox user.