### PR TITLE
fix(apple): use duct to run xcodebuild

### DIFF
--- a/.changes/refactor-command-output.md
+++ b/.changes/refactor-command-output.md
@@ -2,4 +2,4 @@
 "tauri-mobile": patch
 ---
 
-Fixed command execution on environments like Node-API.
+Fixed ADB and xcodebuild execution on environments like Node-API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "duct"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1020,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "simple_logger"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1119,7 @@ dependencies = [
  "colored",
  "core-foundation",
  "deunicode",
+ "duct",
  "dunce",
  "embed-resource",
  "english-numbers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ textwrap = { version = "0.11.0", features = [ "term_size" ] }
 thiserror = "1.0.20"
 toml = { version = "0.5.6", features = [ "preserve_order" ] }
 os_pipe = "1"
+duct = "0.13"
 which = "4.4.0"
 
 [dev-dependencies]

--- a/src/apple/config/mod.rs
+++ b/src/apple/config/mod.rs
@@ -404,11 +404,7 @@ impl Config {
         let new = path(self.app.name());
         std::iter::once(&old)
             .chain(std::iter::once(&new))
-            .filter(|path| {
-                let found = path.is_file();
-                log::info!("IPA {}found at {:?}", if found { "" } else { "not " }, path);
-                found
-            })
+            .filter(|path| path.is_file())
             .next()
             .cloned()
             .ok_or_else(|| (old, new))


### PR DESCRIPTION
`duct` actually sets the stdout/stderr in a way that makes xcodebuild happy. Without it, archiving fails with `Error Domain=NSPOSIXErrorDomain Code=9 "Bad file descriptor"`.