### PR TITLE
fix: allow repo to update with specific branch, fixes #95

### DIFF
--- a/.changes/specific-update-branch.md
+++ b/.changes/specific-update-branch.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Allow to update repo with a specific branch.

--- a/src/apple/deps/xcode_plugin.rs
+++ b/src/apple/deps/xcode_plugin.rs
@@ -190,7 +190,10 @@ impl Context {
     // Step 2: update checkout
     fn update_repo(&self) -> Result<(), Error> {
         self.repo
-            .update("https://github.com/tauri-apps/rust-xcode-plugin.git")
+            .update(
+                "https://github.com/tauri-apps/rust-xcode-plugin.git",
+                "master",
+            )
             .map_err(Error::UpdateFailed)
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -79,7 +79,7 @@ pub fn update(wrapper: &TextWrapper) -> Result<(), Error> {
             path: marker.to_owned(),
             cause,
         })?;
-        repo.update("https://github.com/tauri-apps/tauri-mobile")
+        repo.update("https://github.com/tauri-apps/tauri-mobile", "dev")
             .map_err(Error::UpdateFailed)?;
         println!("Installing updated `tauri-mobile`...");
         bossy::Command::impure_parse("cargo install --force --path")

--- a/src/util/git/repo.rs
+++ b/src/util/git/repo.rs
@@ -121,7 +121,7 @@ impl Repo {
             .map_err(Error::LogFailed)
     }
 
-    pub fn update(&self, url: impl AsRef<OsStr>) -> Result<(), Error> {
+    pub fn update(&self, url: impl AsRef<OsStr>, branch: &str) -> Result<(), Error> {
         let path = self.path();
         if !path.is_dir() {
             let parent = self
@@ -157,7 +157,7 @@ impl Repo {
                 .run_and_wait()
                 .map_err(Error::FetchFailed)?;
             self.git()
-                .command_parse("reset --hard origin/dev")
+                .command_parse(format!("reset --hard origin/{branch}"))
                 .run_and_wait()
                 .map_err(Error::ResetFailed)?;
             self.git()


### PR DESCRIPTION
In #86, we changed the update branch to `dev`, but I missed another one calling this method as well, and it is using the `master` branch.

Due to the update branch for each repo might not be the same, I think we can add a `branch` parameter to the update method to accept a specific branch to update.


fixed #95 
