### PR TITLE
fix: fallback to gradlew from PATH if the template doesn't have one

### DIFF
--- a/.changes/gradlew-path.md
+++ b/.changes/gradlew-path.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": "patch"
+---
+
+Fallback to `gradlew` from `PATH` if the one inside the generated template doesn't exist.

--- a/src/os/linux/mod.rs
+++ b/src/os/linux/mod.rs
@@ -176,14 +176,6 @@ pub fn code_command() -> bossy::Command {
     bossy::Command::impure("code")
 }
 
-pub fn gradlew_command(project_dir: impl AsRef<OsStr>) -> duct::Expression {
-    let gradle_path = Path::new(project_dir.as_ref()).join("gradlew");
-    duct::cmd(
-        &gradle_path,
-        [OsStr::new("--project-dir"), project_dir.as_ref()],
-    )
-}
-
 pub fn replace_path_separator(path: OsString) -> OsString {
     path
 }

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -107,14 +107,6 @@ pub fn code_command() -> bossy::Command {
     bossy::Command::impure("code")
 }
 
-pub fn gradlew_command(project_dir: impl AsRef<OsStr>) -> duct::Expression {
-    let gradle_path = Path::new(project_dir.as_ref()).join("gradlew");
-    duct::cmd(
-        &gradle_path,
-        [OsStr::new("--project-dir"), project_dir.as_ref()],
-    )
-}
-
 pub fn replace_path_separator(path: OsString) -> OsString {
     path
 }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -265,17 +265,6 @@ pub fn code_command() -> bossy::Command {
     bossy::Command::impure_parse("powershell.exe -Command  code")
 }
 
-pub fn gradlew_command(project_dir: impl AsRef<OsStr>) -> duct::Expression {
-    // Path without verbatim prefix.
-    let project_dir = dunce::canonicalize(Path::new(project_dir.as_ref()))
-        .expect("Failed to canonicalize project dir");
-    let gradlew_path = project_dir.join("gradlew.bat");
-    duct::cmd(
-        &gradlew_path,
-        [OsStr::new("--project-dir"), project_dir.as_ref()],
-    )
-}
-
 pub fn replace_path_separator(path: OsString) -> OsString {
     let buf = path
         .encode_wide()


### PR DESCRIPTION
closes https://github.com/tauri-apps/tauri/issues/6367