### PR TITLE
Update build.gradle.kts.hbs to fix Kotlin incorrect version usage

### DIFF
--- a/.changes/build.gradle.kts.hbs.md
+++ b/.changes/build.gradle.kts.hbs.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+This change manually instructs Java and Kotlin to use/generate code for the same JVM target.

--- a/templates/platforms/android-studio/build.gradle.kts.hbs
+++ b/templates/platforms/android-studio/build.gradle.kts.hbs
@@ -1,3 +1,17 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+// https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+tasks.withType(JavaCompile::class.java) {
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
+}
+
+tasks.withType(KotlinCompile::class.java) {
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {


### PR DESCRIPTION
There's an issue where even if you use Java 11 Kotlin will not detect the appropriate version to compile for as a target and so defaults to Java 1.8. To fix this you have to manually tell Kotlin which version to use.

More info here: https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support

This change makes both Java and Kotlin use version 11. This would/should mean that we're forcing users to use a specific version, which may or may not be an issue, but at least it fixes Kotlin building for the wrong target version.

It's worth noting that thus far I haven't had any issues just because Kotlin builds for the wrong target, nor am I entirely certain what issues Kotlin using a later target might fix, but presumably there's security and performance fixes from using a later target version. Newer is always better!!