### PR TITLE
fix: detach process for open_file_with on Windos and macos

### DIFF
--- a/.changes/detach-open-with.md
+++ b/.changes/detach-open-with.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": "patch"
+---
+
+Detach launched processes for CLI `open` commands on macOS and Windwos.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-mobile"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cocoa",
  "colored",

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -95,7 +95,7 @@ pub fn open_file_with(
             Ok(())
         })
         .vars(env.explicit_env())
-        .run()
+        .run_and_detach()
         .map_err(OpenFileError::DuctLaunchFailed)?;
     Ok(())
 }
@@ -115,7 +115,7 @@ pub fn replace_path_separator(path: OsString) -> OsString {
 
 pub fn open_in_xcode(path: impl AsRef<OsStr>) -> Result<(), OpenFileError> {
     duct::cmd("xed", [path.as_ref()])
-        .run()
+        .run_and_detach()
         .map_err(OpenFileError::DuctLaunchFailed)?;
     Ok(())
 }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -198,7 +198,7 @@ fn open_file_with_android_studio(path: impl AsRef<OsStr>, env: &Env) -> Result<(
         ],
     )
     .vars(env.explicit_env())
-    .run()
+    .run_and_detach()
     .map_err(OpenFileError::LaunchFailed)?;
     Ok(())
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri-mobile/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

