### PR TITLE
chore: reuse `defaultArchList`

### DIFF
--- a/templates/platforms/android-studio/buildSrc/src/main/kotlin/RustPlugin.kt.hbs
+++ b/templates/platforms/android-studio/buildSrc/src/main/kotlin/RustPlugin.kt.hbs
@@ -21,7 +21,7 @@ open class RustPlugin : Plugin<Project> {
         val abiList = (findProperty("abiList") as? String)?.split(',') ?: defaultAbiList
 
         val defaultArchList = listOf({{quote-and-join arch-list}});
-        val archList = (findProperty("archList") as? String)?.split(',') ?: listOf({{quote-and-join arch-list}})
+        val archList = (findProperty("archList") as? String)?.split(',') ?: defaultArchList
 
         val targetsList = (findProperty("targetList") as? String)?.split(',') ?: listOf({{quote-and-join target-list}})
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri-mobile/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

