### PR TITLE
fix(android): update the location to libc++_shared.so

### DIFF
--- a/.changes/libc_path.md
+++ b/.changes/libc_path.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Update the path to `libc++_shared.so` for NDK versions 22 and above.

--- a/src/android/ndk.rs
+++ b/src/android/ndk.rs
@@ -249,9 +249,14 @@ impl Env {
         static LIB: &str = "libc++_shared.so";
         let ndk_ver = self.version().unwrap_or_default();
         let so_path = if ndk_ver.triple.major >= 22 {
+            let ndk_triple = if target.triple == "armv7a-linux-androideabi" {
+                "arm-linux-androideabi"
+            } else {
+                target.triple
+            };
             self.prebuilt_dir()?
                 .join("sysroot/usr/lib")
-                .join(target.triple)
+                .join(ndk_triple)
         } else {
             self.ndk_home
                 .join("sources/cxx-stl/llvm-libc++/libs")

--- a/src/android/ndk.rs
+++ b/src/android/ndk.rs
@@ -247,13 +247,17 @@ impl Env {
 
     pub fn libcxx_shared_path(&self, target: Target<'_>) -> Result<PathBuf, MissingToolError> {
         static LIB: &str = "libc++_shared.so";
-        MissingToolError::check_file(
+        let ndk_ver = self.version().unwrap_or_default();
+        let so_path = if ndk_ver.triple.major >= 22 {
+            self.prebuilt_dir()?
+                .join("sysroot/usr/lib")
+                .join(target.triple)
+        } else {
             self.ndk_home
                 .join("sources/cxx-stl/llvm-libc++/libs")
                 .join(target.abi)
-                .join(LIB),
-            LIB,
-        )
+        };
+        MissingToolError::check_file(so_path.join(LIB), LIB)
     }
 
     pub fn ar_path(&self, triple: &str) -> Result<PathBuf, MissingToolError> {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri-mobile/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
The discussion on this topic is in [a Discord thread in the Tauri server](https://discord.com/channels/616186924390023171/1110296482529157311/1110296482529157311).
TL;DR, the path that currently is being used to fetch libc++_shared.so is outdated since the release of Android NDK r22.
Check their [Android NDK changelog for version r22](https://github.com/android/ndk/wiki/Changelog-r22#changes) for details.
This PR aims to update the path to the libc++_shared.so file, and let Android projects that depend on libc++ compile.
libc++ can be used using `println!("cargo:rustc-link-lib=c++_shared");`

For target `armv7a-linux-androideabi`'s binutils tools, they are prefixed as `arm-linux-androideabi`.
Check [the Android NDK guide](https://developer.android.com/ndk/guides/other_build_systems#overview) for details.

Thanks to @simonhyll for all the help!