### PR TITLE
fix(ios): invalid app name for device logs command

### DIFF
--- a/.changes/fix-ios-logs.md
+++ b/.changes/fix-ios-logs.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Fixes `Device::run` not showing logs.

--- a/src/apple/ios_deploy/run.rs
+++ b/src/apple/ios_deploy/run.rs
@@ -49,7 +49,7 @@ pub fn run_and_debug(
             .map_err(RunAndDebugError::DeployFailed)?
             .wait()
             .map_err(RunAndDebugError::DeployFailed)?;
-        duct::cmd("idevicesyslog", ["--process", config.app().name()])
+        duct::cmd("idevicesyslog", ["--process", config.app().stylized_name()])
             .vars(env.explicit_env())
             .start()
             .map_err(RunAndDebugError::DeployFailed)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist
- [ ] This PR will resolve #___
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri-mobile/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

