### PR TITLE
fix(apple): allow selecting visionOS simulator

### DIFF
--- a/.changes/allow-vision-os.md
+++ b/.changes/allow-vision-os.md
@@ -1,0 +1,5 @@
+---
+"tauri-mobile": patch
+---
+
+Allow selecting "Apple Vision Pro" as an emulator.

--- a/src/apple/simctl/device_list.rs
+++ b/src/apple/simctl/device_list.rs
@@ -33,7 +33,7 @@ fn parse_device_list(output: &std::process::Output) -> Result<BTreeSet<Device>, 
     let devices = serde_json::from_str::<DeviceListOutput>(&stdout)?
         .devices
         .into_iter()
-        .filter(|(k, _)| k.contains("iOS"))
+        .filter(|(k, _)| k.contains("iOS") || k.contains("xrOS"))
         .flat_map(|(_, v)| v)
         .collect();
 


### PR DESCRIPTION
This fixes the simulator target selection incorrectly filtering out the visionOS target (it's just iPadOS after all).

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist
- [ ] This PR will resolve #___
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri-mobile/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

