### PR TITLE
fix: allow '-' and '.' in identifier

### DIFF
--- a/src/config/app/domain.rs
+++ b/src/config/app/domain.rs
@@ -141,7 +141,7 @@ pub fn check_domain_syntax(domain_name: &str) -> Result<(), DomainError> {
         }
         let mut bad_chars = Vec::new();
         for c in label.chars() {
-            if !c.is_ascii_alphanumeric() && !bad_chars.contains(&c) {
+            if !c.is_ascii_alphanumeric() && !['.', '-'].contains(&c) && !bad_chars.contains(&c) {
                 bad_chars.push(c);
             }
         }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist

- [ ] This PR will resolve #\_\_\_
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
(Please forgive me for not being very good at English.)

Fixed an issue where domains containing '-' or '.' could not be used in `identifier` of tauri.conf.json.
I apologize if there is a reason for this specification.
