### PR TITLE
fix(template): use the correct function on wry desktop

### DIFF
--- a/templates/apps/wry/gen/bin/desktop.rs.hbs
+++ b/templates/apps/wry/gen/bin/desktop.rs.hbs
@@ -1,5 +1,5 @@
 
 fn main() {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    {{snake-case app.name}}::start_app().unwrap();
+    {{snake-case app.name}}::main().unwrap();
 }


### PR DESCRIPTION
Use `main` instead of `start_app` to start the application in `wry template` on desktop.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [x] No

### Checklist

- [x] This PR will resolve #249 
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [x] It can be built on all targets and pass CI/CD.

### Other information

