### PR TITLE
fix: conflict between Apple and Android targets

### DIFF
--- a/.changes/fix-targets.md
+++ b/.changes/fix-targets.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Fixes conflicts between Apple and Android targets.

--- a/.changes/fix-targets.md
+++ b/.changes/fix-targets.md
@@ -1,5 +1,5 @@
 ---
-"cargo-mobile2": patch
+"cargo-mobile2": minor
 ---
 
-Fixes conflicts between Apple and Android targets.
+Fixes conflicts between Apple and Android targets. `Target::name_list` now returns `Vec<&str>`.

--- a/src/android/cli.rs
+++ b/src/android/cli.rs
@@ -52,12 +52,12 @@ pub enum Command {
     Open,
     #[structopt(name = "check", about = "Checks if code compiles for target(s)")]
     Check {
-        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = Target::name_list())]
+        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = &Target::name_list())]
         targets: Vec<String>,
     },
     #[structopt(name = "build", about = "Builds dynamic libraries for target(s)")]
     Build {
-        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = Target::name_list())]
+        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = &Target::name_list())]
         targets: Vec<String>,
         #[structopt(flatten)]
         profile: cli::Profile,
@@ -97,7 +97,7 @@ pub enum Command {
 pub enum ApkSubcommand {
     #[structopt(about = "build APKs (Android Package Kit)")]
     Build {
-        #[structopt(name = "targets", possible_values = Target::name_list())]
+        #[structopt(name = "targets", possible_values = &Target::name_list())]
         /// Which targets to build (all by default).
         targets: Vec<String>,
         #[structopt(flatten)]
@@ -110,7 +110,7 @@ pub enum ApkSubcommand {
 pub enum AabSubcommand {
     #[structopt(about = "build AABs (Android App Bundle)")]
     Build {
-        #[structopt(name = "targets", possible_values = Target::name_list())]
+        #[structopt(name = "targets", possible_values = &Target::name_list())]
         /// Which targets to build (all by default).
         targets: Vec<String>,
         #[structopt(flatten)]

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -158,12 +158,8 @@ impl<'a> TargetTrait<'a> for Target<'a> {
         })
     }
 
-    fn name_list() -> &'static [&'a str]
-    where
-        Self: 'static,
-    {
-        static INSTANCE: OnceCell<Vec<&str>> = OnceCell::new();
-        INSTANCE.get_or_init(|| Self::all().keys().copied().collect::<Vec<_>>())
+    fn name_list() -> Vec<&'a str> {
+        Self::all().keys().copied().collect::<Vec<_>>()
     }
 
     fn triple(&'a self) -> &'a str {

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -158,6 +158,14 @@ impl<'a> TargetTrait<'a> for Target<'a> {
         })
     }
 
+    fn name_list() -> &'static [&'a str]
+    where
+        Self: 'static,
+    {
+        static INSTANCE: OnceCell<Vec<&str>> = OnceCell::new();
+        INSTANCE.get_or_init(|| Self::all().keys().copied().collect::<Vec<_>>())
+    }
+
     fn triple(&'a self) -> &'a str {
         self.triple
     }

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -65,12 +65,12 @@ pub enum Command {
     Open,
     #[structopt(name = "check", about = "Checks if code compiles for target(s)")]
     Check {
-        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = Target::name_list())]
+        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = &Target::name_list())]
         targets: Vec<String>,
     },
     #[structopt(name = "build", about = "Builds static libraries for target(s)")]
     Build {
-        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = Target::name_list())]
+        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = &Target::name_list())]
         targets: Vec<String>,
         #[structopt(flatten)]
         profile: cli::Profile,
@@ -79,7 +79,7 @@ pub enum Command {
     Archive {
         #[structopt(long = "build-number")]
         build_number: Option<u32>,
-        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = Target::name_list())]
+        #[structopt(name = "targets", default_value = Target::DEFAULT_KEY, possible_values = &Target::name_list())]
         targets: Vec<String>,
         #[structopt(flatten)]
         profile: cli::Profile,

--- a/src/apple/device/devicectl/device_list.rs
+++ b/src/apple/device/devicectl/device_list.rs
@@ -122,6 +122,6 @@ pub fn device_list<'a>(env: &Env) -> Result<BTreeSet<Device<'a>>, DeviceListErro
         .run()
         .map_err(DeviceListError::DetectionFailed)?;
 
-    let contents = read_to_string(&json_output_path_)?;
+    let contents = read_to_string(json_output_path_)?;
     parse_device_list(contents)
 }

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -197,6 +197,6 @@ pub fn list_devices<'a>(env: &Env) -> Result<BTreeSet<Device<'a>>, String> {
     }
 }
 
-pub fn list_simulators<'a>(env: &Env) -> Result<BTreeSet<Simulator>, String> {
+pub fn list_simulators(env: &Env) -> Result<BTreeSet<Simulator>, String> {
     simctl::device_list(env).map_err(|e| e.to_string())
 }

--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -188,12 +188,8 @@ impl<'a> TargetTrait<'a> for Target<'a> {
         })
     }
 
-    fn name_list() -> &'static [&'a str]
-    where
-        Self: 'static,
-    {
-        static INSTANCE: OnceCell<Vec<&str>> = OnceCell::new();
-        INSTANCE.get_or_init(|| Self::all().keys().copied().collect::<Vec<_>>())
+    fn name_list() -> Vec<&'a str> {
+        Self::all().keys().copied().collect::<Vec<_>>()
     }
 
     fn triple(&'a self) -> &'a str {

--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -188,6 +188,14 @@ impl<'a> TargetTrait<'a> for Target<'a> {
         })
     }
 
+    fn name_list() -> &'static [&'a str]
+    where
+        Self: 'static,
+    {
+        static INSTANCE: OnceCell<Vec<&str>> = OnceCell::new();
+        INSTANCE.get_or_init(|| Self::all().keys().copied().collect::<Vec<_>>())
+    }
+
     fn triple(&'a self) -> &'a str {
         self.triple
     }

--- a/src/apple/version_number.rs
+++ b/src/apple/version_number.rs
@@ -49,7 +49,7 @@ impl FromStr for VersionNumber {
 
     fn from_str(v: &str) -> Result<Self, Self::Err> {
         match v.split('.').count() {
-            1 | 2 | 3 => {
+            1..=3 => {
                 let triple = VersionTriple::from_str(v)?;
                 Ok(Self {
                     triple,

--- a/src/target.rs
+++ b/src/target.rs
@@ -10,9 +10,7 @@ pub trait TargetTrait<'a>: Debug + Sized {
 
     fn all() -> &'a BTreeMap<&'a str, Self>;
 
-    fn name_list() -> &'static [&'a str]
-    where
-        Self: 'static;
+    fn name_list() -> Vec<&'a str>;
 
     fn default_ref() -> &'a Self {
         Self::all()

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,5 +1,4 @@
 use crate::util;
-use once_cell_regex::exports::once_cell::sync::OnceCell;
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug, Display},
@@ -13,11 +12,7 @@ pub trait TargetTrait<'a>: Debug + Sized {
 
     fn name_list() -> &'static [&'a str]
     where
-        Self: 'static,
-    {
-        static INSTANCE: OnceCell<Vec<&str>> = OnceCell::new();
-        INSTANCE.get_or_init(|| Self::all().keys().copied().collect::<Vec<_>>())
-    }
+        Self: 'static;
 
     fn default_ref() -> &'a Self {
         Self::all()


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist

- [ ] This PR will resolve #\_\_\_
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information

The TargetTrait used a static value to determine the `name_list` which caused a conflict on the Android vs Apple implementation. Moving the static to each type fixes it.