### PR TITLE
fix(apple): list disconnected devices, reverts #247

### DIFF
--- a/.changes/disconnected-devicectl.md
+++ b/.changes/disconnected-devicectl.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Use devicectl even if iOS device is disconnected.

--- a/src/apple/device/devicectl/device_list.rs
+++ b/src/apple/device/devicectl/device_list.rs
@@ -78,7 +78,6 @@ fn parse_device_list<'a>(json: String) -> Result<BTreeSet<Device<'a>>, DeviceLis
         .into_iter()
         .filter(|device| {
             device.connection_properties.tunnel_state != "unavailable"
-                && device.connection_properties.tunnel_state != "disconnected"
                 && (device.hardware_properties.platform.contains("iOS")
                     || device.hardware_properties.platform.contains("xrOS"))
         })


### PR DESCRIPTION
From my latest tests we can use devicectl even if the device is disconnected, if we skip it, we end up using ios-deploy which won't work on latest iOS/macOS devices

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes
- [ ] No

### Checklist

- [ ] This PR will resolve #\_\_\_
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
- [ ] It can be built on all targets and pass CI/CD.

### Other information
