### PR TITLE
feat: development team is now optional

### DIFF
--- a/.changes/optional-development-team.md
+++ b/.changes/optional-development-team.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+The development team configuration is now optional so you can develop on a simulator without a signing certificate.

--- a/src/apple/config/mod.rs
+++ b/src/apple/config/mod.rs
@@ -281,7 +281,7 @@ impl VersionInfo {
 pub struct Config {
     #[serde(skip_serializing)]
     app: App,
-    development_team: String,
+    development_team: Option<String>,
     project_dir: String,
     bundle_version: VersionNumber,
     bundle_version_short: VersionTriple,
@@ -296,7 +296,12 @@ impl Config {
     pub fn from_raw(app: App, raw: Option<Raw>) -> Result<Self, Error> {
         let raw = raw.ok_or_else(|| Error::DevelopmentTeamMissing)?;
 
-        if raw.development_team.is_empty() {
+        if raw
+            .development_team
+            .as_ref()
+            .map(|t| t.is_empty())
+            .unwrap_or_default()
+        {
             return Err(Error::DevelopmentTeamEmpty);
         }
 

--- a/src/apple/config/raw.rs
+++ b/src/apple/config/raw.rs
@@ -9,7 +9,6 @@ use std::fmt::{self, Debug, Display};
 #[derive(Debug)]
 pub enum DetectError {
     DeveloperTeamLookupFailed(teams::Error),
-    DeveloperTeamsEmpty,
 }
 
 impl Display for DetectError {
@@ -18,7 +17,6 @@ impl Display for DetectError {
             Self::DeveloperTeamLookupFailed(err) => {
                 write!(f, "Failed to find Apple developer teams: {}", err)
             }
-            Self::DeveloperTeamsEmpty => write!(f, "No Apple developer teams were detected."),
         }
     }
 }
@@ -116,7 +114,7 @@ pub struct PListPair {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Raw {
-    pub development_team: String,
+    pub development_team: Option<String>,
     pub project_dir: Option<String>,
     pub ios_no_default_features: Option<bool>,
     pub ios_features: Option<Vec<String>>,
@@ -137,9 +135,8 @@ impl Raw {
             teams::find_development_teams().map_err(DetectError::DeveloperTeamLookupFailed)?;
         Ok(Self {
             development_team: development_teams
-                .get(0)
-                .map(|development_team| development_team.id.clone())
-                .ok_or_else(|| DetectError::DeveloperTeamsEmpty)?,
+                .first()
+                .map(|development_team| development_team.id.clone()),
             project_dir: None,
             ios_no_default_features: None,
             ios_features: None,
@@ -221,7 +218,7 @@ impl Raw {
             }
         };
         Ok(Self {
-            development_team,
+            development_team: Some(development_team),
             project_dir: None,
             ios_no_default_features: None,
             ios_features: None,

--- a/src/apple/device/devicectl/mod.rs
+++ b/src/apple/device/devicectl/mod.rs
@@ -1,5 +1,5 @@
 mod device_list;
 mod run;
 
-pub use device_list::{device_list, DeviceListError};
-pub use run::{run, RunError};
+pub use device_list::device_list;
+pub use run::run;

--- a/src/apple/device/simctl/mod.rs
+++ b/src/apple/device/simctl/mod.rs
@@ -10,8 +10,8 @@ use std::fmt::Display;
 mod device_list;
 mod run;
 
-pub use device_list::{device_list, DeviceListError};
-pub use run::{run, RunError};
+pub use device_list::device_list;
+pub use run::run;
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Device {

--- a/templates/platforms/xcode/project.yml.hbs
+++ b/templates/platforms/xcode/project.yml.hbs
@@ -13,7 +13,9 @@ settingGroups:
     base:
       PRODUCT_NAME: {{app.stylized-name}}
       PRODUCT_BUNDLE_IDENTIFIER: {{reverse-domain app.domain}}.{{app.name}}
+      {{#if apple.development-team}}
       DEVELOPMENT_TEAM: {{apple.development-team}}
+      {{/if}}
 targetTemplates:
   app:
     type: application


### PR DESCRIPTION
Codesigning is not required when using the iOS simulator, so this simplifies development.