### PR TITLE
fix: dup stdout/stderr to spawn processes on NAPI contexts

### DIFF
--- a/.changes/fix-duct-pipes.md
+++ b/.changes/fix-duct-pipes.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Fix child process spawning on NAPI contexts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "once-cell-regex",
  "openssl",
  "os_info",
+ "os_pipe",
  "path_abs",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ thiserror = "1.0"
 toml = { version = "0.8", features = [ "preserve_order" ] }
 duct = "0.13"
 which = "5.0"
+os_pipe = "1"
 
 [dev-dependencies]
 rstest = "0.18"

--- a/src/android/adb/device_name.rs
+++ b/src/android/adb/device_name.rs
@@ -40,6 +40,7 @@ pub fn device_name(env: &Env, serial_no: &str) -> Result<String, Error> {
                     cmd.args(["emu", "avd", "name"]);
                     Ok(())
                 })
+                .stderr_capture()
                 .stdout_capture()
                 .start()?
                 .wait()?,
@@ -53,6 +54,7 @@ pub fn device_name(env: &Env, serial_no: &str) -> Result<String, Error> {
                     cmd.args(["shell", "dumpsys", "bluetooth_manager"]);
                     Ok(())
                 })
+                .stderr_capture()
                 .stdout_capture()
                 .start()?
                 .wait()?,

--- a/src/android/adb/get_prop.rs
+++ b/src/android/adb/get_prop.rs
@@ -1,10 +1,11 @@
-use super::adb;
 use crate::{
     android::env::Env,
     util::cli::{Report, Reportable},
 };
 use std::str;
 use thiserror::Error;
+
+use super::adb;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -44,7 +45,9 @@ pub fn get_prop(env: &Env, serial_no: &str, prop: &str) -> Result<String, Error>
             Ok(())
         })
         .stdout_capture()
+        .stderr_capture()
         .start()?;
+
     let output = handle.wait()?;
     super::check_authorized(output).map_err(|source| Error::LookupFailed {
         prop: prop.to_owned(),

--- a/src/android/bundletool.rs
+++ b/src/android/bundletool.rs
@@ -5,6 +5,8 @@ use crate::util::cli::{Report, Reportable};
 use std::path::PathBuf;
 use thiserror::Error;
 
+use crate::DuctExpressionExt;
+
 #[cfg(not(target_os = "macos"))]
 pub const BUNDLE_TOOL_JAR_INFO: BundletoolJarInfo = BundletoolJarInfo { version: "1.8.0" };
 
@@ -35,10 +37,12 @@ impl BundletoolJarInfo {
 
     fn run_command(&self) -> duct::Expression {
         let installation_path = self.installation_path();
-        duct::cmd("java", ["-jar"]).before_spawn(move |cmd| {
-            cmd.arg(&installation_path);
-            Ok(())
-        })
+        duct::cmd("java", ["-jar"])
+            .dup_stdio()
+            .before_spawn(move |cmd| {
+                cmd.arg(&installation_path);
+                Ok(())
+            })
     }
 }
 
@@ -49,7 +53,7 @@ pub fn command() -> duct::Expression {
     }
     #[cfg(target_os = "macos")]
     {
-        duct::cmd!("bundletool")
+        duct::cmd!("bundletool").dup_stdio()
     }
 }
 

--- a/src/android/emulator/avd_list.rs
+++ b/src/android/emulator/avd_list.rs
@@ -15,6 +15,7 @@ pub fn avd_list(env: &Env) -> Result<BTreeSet<Emulator>, Error> {
         ["-list-avds"],
     )
     .vars(env.explicit_env())
+    .stderr_capture()
     .read()
     .map(|raw_list| {
         raw_list

--- a/src/android/emulator/mod.rs
+++ b/src/android/emulator/mod.rs
@@ -34,6 +34,7 @@ impl Emulator {
             ["-avd", &self.name],
         )
         .vars(env.explicit_env())
+        .dup_stdio()
     }
 
     pub fn start(&self, env: &Env) -> Result<Handle, std::io::Error> {

--- a/src/android/ndk.rs
+++ b/src/android/ndk.rs
@@ -298,6 +298,7 @@ impl Env {
                         cmd.arg(&elf_path);
                         Ok(())
                     })
+                    .stderr_capture()
                     .read()?
                     .as_str(),
             )

--- a/src/apple/deps/update.rs
+++ b/src/apple/deps/update.rs
@@ -98,6 +98,7 @@ impl Outdated {
         }
 
         duct::cmd("brew", ["outdated", "--json=v2"])
+            .stderr_capture()
             .stdout_capture()
             .run()
             .map_err(OutdatedError::CommandFailed)
@@ -112,6 +113,7 @@ impl Outdated {
 
     pub fn load(gem_cache: &mut GemCache) -> Result<Self, OutdatedError> {
         let outdated_strings = duct::cmd("gem", ["outdated"])
+            .stderr_capture()
             .read()
             .map_err(OutdatedError::CommandFailed)?;
         let packages = Self::outdated_brew_deps()?

--- a/src/apple/device/devicectl/device_list.rs
+++ b/src/apple/device/devicectl/device_list.rs
@@ -116,6 +116,7 @@ pub fn device_list<'a>(env: &Env) -> Result<BTreeSet<Device<'a>>, DeviceListErro
             cmd.arg(&json_output_path);
             Ok(())
         })
+        .stderr_capture()
         .stdout_capture()
         .vars(env.explicit_env())
         .run()

--- a/src/apple/device/devicectl/run.rs
+++ b/src/apple/device/devicectl/run.rs
@@ -63,8 +63,7 @@ pub fn run(
 
         duct::cmd("xcrun", ["devicectl", "manage", "pair", "--device", id])
             .vars(env.explicit_env())
-            .stdout_capture()
-            .stderr_capture()
+            .dup_stdio()
             .run()
             .map_err(RunError::DeployFailed)?;
     }
@@ -89,7 +88,8 @@ pub fn run(
             .arg("--json-output")
             .arg(&json_output_path_);
         Ok(())
-    });
+    })
+    .dup_stdio();
 
     cmd.run().map_err(RunError::DeployFailed)?;
 
@@ -115,7 +115,8 @@ pub fn run(
             &app_id,
         ],
     )
-    .vars(env.explicit_env());
+    .vars(env.explicit_env())
+    .dup_stdio();
 
     if non_interactive {
         launcher_cmd.start().map_err(RunError::DeployFailed)
@@ -128,6 +129,7 @@ pub fn run(
 
         duct::cmd("idevicesyslog", ["--process", config.app().stylized_name()])
             .vars(env.explicit_env())
+            .dup_stdio()
             .start()
             .map_err(RunError::DeployFailed)
     }

--- a/src/apple/device/ios_deploy/run.rs
+++ b/src/apple/device/ios_deploy/run.rs
@@ -39,7 +39,8 @@ pub fn run_and_debug(
                 cmd.arg("--justlaunch");
             }
             Ok(())
-        });
+        })
+        .dup_stdio();
 
     if non_interactive {
         Ok(deploy_cmd.start().map_err(RunAndDebugError::DeployFailed)?)
@@ -51,6 +52,7 @@ pub fn run_and_debug(
             .map_err(RunAndDebugError::DeployFailed)?;
         duct::cmd("idevicesyslog", ["--process", config.app().stylized_name()])
             .vars(env.explicit_env())
+            .dup_stdio()
             .start()
             .map_err(RunAndDebugError::DeployFailed)
     }

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -152,7 +152,8 @@ impl<'a> Device<'a> {
                         }
                         cmd.arg("-o").arg(&ipa_path).arg("-d").arg(&export_dir);
                         Ok(())
-                    });
+                    })
+                    .dup_stdio();
 
                 cmd.run().map_err(RunError::UnzipFailed)?;
 

--- a/src/apple/device/simctl/mod.rs
+++ b/src/apple/device/simctl/mod.rs
@@ -59,6 +59,7 @@ impl Device {
             ],
         )
         .vars(env.explicit_env())
+        .dup_stdio()
     }
 
     pub fn start(&self, env: &Env) -> std::io::Result<duct::Handle> {

--- a/src/apple/device/simctl/run.rs
+++ b/src/apple/device/simctl/run.rs
@@ -38,7 +38,8 @@ pub fn run(
         .before_spawn(move |cmd| {
             cmd.arg(&app_dir);
             Ok(())
-        });
+        })
+        .dup_stdio();
 
     let handle = cmd.start().map_err(RunError::DeployFailed)?;
 
@@ -46,8 +47,9 @@ pub fn run(
 
     let app_id = format!("{}.{}", config.app().reverse_domain(), config.app().name());
 
-    let mut launcher_cmd =
-        duct::cmd("xcrun", ["simctl", "launch", id, &app_id]).vars(env.explicit_env());
+    let mut launcher_cmd = duct::cmd("xcrun", ["simctl", "launch", id, &app_id])
+        .vars(env.explicit_env())
+        .dup_stdio();
 
     if non_interactive {
         launcher_cmd = launcher_cmd.before_spawn(|cmd| {
@@ -79,6 +81,7 @@ pub fn run(
             ],
         )
         .vars(env.explicit_env())
+        .dup_stdio()
         .start()
         .map_err(RunError::DeployFailed)
     }

--- a/src/apple/project.rs
+++ b/src/apple/project.rs
@@ -12,6 +12,7 @@ use crate::{
         cli::{Report, Reportable, TextWrapper},
         ln,
     },
+    DuctExpressionExt,
 };
 use std::path::{Path, PathBuf};
 
@@ -198,6 +199,7 @@ pub fn gen(
             cmd.arg(&project_yml_path);
             Ok(())
         })
+        .dup_stdio()
         .run()
         .map_err(Error::XcodegenFailed)?;
 
@@ -209,6 +211,7 @@ pub fn gen(
                 &format!("--project-directory={}", dest.display()),
             ],
         )
+        .dup_stdio()
         .run()
         .map_err(Error::PodInstallFailed)?;
     }

--- a/src/apple/system_profile.rs
+++ b/src/apple/system_profile.rs
@@ -31,7 +31,7 @@ impl DeveloperTools {
         // The `-xml` flag can be used to get this info in plist format, but
         // there don't seem to be any high quality plist crates, and parsing
         // XML sucks, we'll be lazy for now.
-        let command = duct::cmd("system_profiler", ["SPDeveloperToolsDataType"]);
+        let command = duct::cmd("system_profiler", ["SPDeveloperToolsDataType"]).stderr_capture();
         let command_string = format!("{command:?}");
         let output = command.read().map_err(util::RunAndSearchError::from)?;
         if output.is_empty() {

--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -340,6 +340,7 @@ impl<'a> Target<'a> {
                     .arg("build");
                 Ok(())
             })
+            .dup_stdio()
             .start()?
             .wait()?;
         Ok(())
@@ -359,6 +360,7 @@ impl<'a> Target<'a> {
                     "xcrun",
                     ["agvtool", "new-version", "-all", &build_number.to_string()],
                 )
+                .dup_stdio()
                 .run()
             })
             .map_err(ArchiveError::SetVersionFailed)?;
@@ -389,6 +391,7 @@ impl<'a> Target<'a> {
                     .arg(&archive_path);
                 Ok(())
             })
+            .dup_stdio()
             .start()?
             .wait()?;
 
@@ -424,6 +427,7 @@ impl<'a> Target<'a> {
                     .arg(&export_dir);
                 Ok(())
             })
+            .dup_stdio()
             .start()?
             .wait()?;
 

--- a/src/apple/teams.rs
+++ b/src/apple/teams.rs
@@ -12,6 +12,7 @@ pub fn get_pem_list(name_substr: &str) -> std::io::Result<std::process::Output> 
         "security",
         ["find-certificate", "-p", "-a", "-c", name_substr],
     )
+    .stderr_capture()
     .stdout_capture()
     .run()
 }

--- a/src/doctor/section/apple.rs
+++ b/src/doctor/section/apple.rs
@@ -2,6 +2,7 @@ use super::{Item, Section};
 use crate::{
     apple::{deps::xcode_plugin, system_profile::DeveloperTools, teams},
     util::prompt,
+    DuctExpressionExt,
 };
 use std::path::Path;
 
@@ -33,6 +34,7 @@ fn validate_developer_dir() -> Result<String, String> {
             };
             if answer {
                 duct::cmd("xcode-select", ["-s", SUGGESTED])
+                    .dup_stdio()
                     .run()
                     .map_err(|err| format!("Failed to update Xcode developer dir: {}", err))?;
                 Path::new(SUGGESTED)
@@ -112,12 +114,14 @@ pub fn check() -> Section {
         .with_item(validate_developer_dir())
         .with_item(
             duct::cmd("ios-deploy", ["--version"])
+                .stderr_capture()
                 .read()
                 .map(|version| format!("ios-deploy v{}", version.trim()))
                 .map_err(|err| format!("Failed to check ios-deploy version: {}", err)),
         )
         .with_item(
             duct::cmd("xcodegen", ["--version"])
+                .stderr_capture()
                 .read()
                 .map(|version| version.trim().replace("Version: ", "XcodeGen v"))
                 .map_err(|err| format!("Failed to check ios-deploy version: {}", err)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@ pub static NAME: &str = "mobile";
 trait DuctExpressionExt {
     fn vars(self, vars: impl IntoIterator<Item = (impl AsRef<OsStr>, impl AsRef<OsStr>)>) -> Self;
     fn run_and_detach(self) -> Result<(), std::io::Error>;
+    // Sets the stdin, stdout and stderr to properly
+    // show the command output in a Node.js wrapper (napi-rs).
+    fn dup_stdio(&self) -> Self;
 }
 
 impl DuctExpressionExt for duct::Expression {
@@ -83,5 +86,11 @@ impl DuctExpressionExt for duct::Expression {
         .stderr_null()
         .start()?;
         Ok(())
+    }
+
+    fn dup_stdio(&self) -> Self {
+        self.stdin_file(os_pipe::dup_stdin().unwrap())
+            .stdout_file(os_pipe::dup_stdout().unwrap())
+            .stderr_file(os_pipe::dup_stderr().unwrap())
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,7 +1,10 @@
-use crate::util::{
-    self,
-    cli::{Report, TextWrapper},
-    repo::{self, Repo},
+use crate::{
+    util::{
+        self,
+        cli::{Report, TextWrapper},
+        repo::{self, Repo},
+    },
+    DuctExpressionExt,
 };
 use std::{
     fmt::{self, Display},
@@ -81,6 +84,7 @@ pub fn update(wrapper: &TextWrapper) -> Result<(), Error> {
         println!("Installing updated `cargo-mobile2`...");
         let repo_c = repo.clone();
         duct::cmd("cargo", ["install", "--force", "--path"])
+            .dup_stdio()
             .before_spawn(move |cmd| {
                 cmd.arg(repo_c.path());
                 cmd.args(["--no-default-features", "--features"]);

--- a/src/util/cargo.rs
+++ b/src/util/cargo.rs
@@ -117,6 +117,7 @@ impl<'a> CargoCommand<'a> {
         duct::cmd("cargo", args)
             .vars(env.explicit_env())
             .vars(explicit_cargo_env())
+            .dup_stdio()
     }
 }
 

--- a/src/util/git/lfs.rs
+++ b/src/util/git/lfs.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use crate::DuctExpressionExt;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[cfg(not(target_os = "macos"))]
@@ -36,6 +38,7 @@ pub fn ensure_present() -> Result<(), Error> {
         }
     }
     duct::cmd("git", ["lfs", "install"])
+        .dup_stdio()
         .run()
         .map_err(Error::InstallFailed)?;
     Ok(())

--- a/src/util/git/repo.rs
+++ b/src/util/git/repo.rs
@@ -89,11 +89,13 @@ impl Repo {
                 .map_err(Error::FetchFailed)?;
             let local = git
                 .command_parse("rev-parse HEAD")
+                .stderr_capture()
                 .stdout_capture()
                 .run()
                 .map_err(Error::RevParseLocalFailed)?;
             let remote = git
                 .command_parse("rev-parse @{u}")
+                .stderr_capture()
                 .stdout_capture()
                 .run()
                 .map_err(Error::RevParseRemoteFailed)?;

--- a/src/util/ln.rs
+++ b/src/util/ln.rs
@@ -5,6 +5,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::DuctExpressionExt;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LinkType {
     Hard,
@@ -198,6 +200,7 @@ impl<'a> Call<'a> {
         args.push(&source);
         args.push(&target_override);
         duct::cmd("ln", args)
+            .dup_stdio()
             .run()
             .map_err(|err| self.make_error(ErrorCause::CommandFailed(err)))?;
         Ok(())

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -53,6 +53,7 @@ pub fn reverse_domain(domain: &str) -> String {
 
 pub fn rustup_add(triple: &str) -> Result<ExitStatus, std::io::Error> {
     duct::cmd("rustup", ["target", "add", triple])
+        .dup_stdio()
         .run()
         .map(|o| o.status)
 }
@@ -676,15 +677,19 @@ pub fn gradlew(
             [OsStr::new("--project-dir"), project_dir.as_ref()],
         )
         .vars(env.explicit_env())
+        .dup_stdio()
     } else if duct::cmd(gradlew, ["-v"])
+        .dup_stdio()
         .run()
         .map(|o| o.status.success())
         .unwrap_or(false)
     {
         duct::cmd(gradlew, [OsStr::new("--project-dir"), project_dir.as_ref()])
             .vars(env.explicit_env())
+            .dup_stdio()
     } else {
         duct::cmd(gradle, [OsStr::new("--project-dir"), project_dir.as_ref()])
             .vars(env.explicit_env())
+            .dup_stdio()
     }
 }


### PR DESCRIPTION
A recent [duct change](https://github.com/oconnor663/duct.rs/commit/bb6a599bf99fcd5f58cfc6f5da051a8dbe9c5d1a) breaks cargo-mobile2 usage on NAPI contexts. We rely on the dup stdout/stdio/stderr otherwise process spawning fails on Node.js bindings.

Bug report: https://github.com/tauri-apps/tauri/issues/6203