### PR TITLE
fix(android): use `install -r` to try and replace existing apk

### DIFF
--- a/.changes/adb-replace.md
+++ b/.changes/adb-replace.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Use `adb install -r` to try replacing the android application while installing it on the device. This elimnates the need to uninstall the application from a previous run when using a real device.

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -237,11 +237,8 @@ impl<'a> Device<'a> {
 
         self.adb(env)
             .before_spawn(move |cmd| {
-                cmd.args([
-                    "install",
-                    "-r",
-                    apk_path.to_str().unwrap()
-                ]);
+                cmd.args(["install", "-r"]);
+                cmd.arg(&apk_path);
                 Ok(())
             })
             .dup_stdio()

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -237,8 +237,11 @@ impl<'a> Device<'a> {
 
         self.adb(env)
             .before_spawn(move |cmd| {
-                cmd.arg("install");
-                cmd.arg(&apk_path);
+                cmd.args([
+                    "install",
+                    "-r",
+                    apk_path.to_str().unwrap()
+                ]);
                 Ok(())
             })
             .dup_stdio()


### PR DESCRIPTION
Fixes tauri-apps/tauri#9067

Adds the `-r` flag to ADB install commands which allows replacing applications if they are already installed.
This fixes INSTALL_FAILED_ALREADY_EXISTS errors that appear when programs are redeployed.
