### PR TITLE
feat: show friendly error message if gradle not found

### DIFF
--- a/src/android/aab.rs
+++ b/src/android/aab.rs
@@ -78,7 +78,13 @@ pub fn build(
             });
             Ok(())
         })
-        .start()?
+        .start()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+               log::error!("`gradlew` not found. Make sure you have the Android SDK installed and added to your PATH");
+            }
+            err
+        })?
         .wait()?;
 
     let mut outputs = Vec::new();

--- a/src/android/apk.rs
+++ b/src/android/apk.rs
@@ -105,7 +105,13 @@ pub fn build(
             });
             Ok(())
         })
-        .start()?
+        .start()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+               log::error!("`gradlew` not found. Make sure you have the Android SDK installed and added to your PATH");
+            }
+            err
+        })?
         .wait()?;
 
     let mut outputs = Vec::new();


### PR DESCRIPTION
Show a helpful message. if gradle is not found on system.
Generic messages like "No such file or directory (os error 2)" is not helpful.

Took a long time to figure out what is missing.