### PR TITLE
fix(init): wrap `.cargo/config.toml` path in quotes

### DIFF
--- a/.changes/rust-flags-path-quotes.md
+++ b/.changes/rust-flags-path-quotes.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": "patch"
+---
+
+Generate `.cargo/config.toml` with paths wrapped in quote.

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -213,9 +213,10 @@ impl<'a> Target<'a> {
             linker: Some(linker),
             rustflags: vec![
                 "-L".to_owned(),
-                dunce::simplified(&config.app().prefix_path(".cargo"))
+                format!("\"{}\"", dunce::simplified(&config.app().prefix_path(".cargo"))
                     .display()
-                    .to_string(),
+                    .to_string()
+                ),
                 "-Clink-arg=-landroid".to_owned(),
                 "-Clink-arg=-llog".to_owned(),
                 "-Clink-arg=-lOpenSLES".to_owned(),

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -213,9 +213,9 @@ impl<'a> Target<'a> {
             linker: Some(linker),
             rustflags: vec![
                 "-L".to_owned(),
-                format!("\"{}\"", dunce::simplified(&config.app().prefix_path(".cargo"))
-                    .display()
-                    .to_string()
+                format!(
+                    "\"{}\"",
+                    dunce::simplified(&config.app().prefix_path(".cargo")).display()
                 ),
                 "-Clink-arg=-landroid".to_owned(),
                 "-Clink-arg=-llog".to_owned(),


### PR DESCRIPTION
## Original issue:
closes tauri-apps/tauri#6627

## Changes:
Added quotes around the path arg to the `.cargo` file