### PR TITLE
fix: add '-' to allowed characters in domain names

### DIFF
--- a/.changes/fix-domains.md
+++ b/.changes/fix-domains.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Fix the domain checker to allow '-' in domain names.

--- a/src/config/app/domain.rs
+++ b/src/config/app/domain.rs
@@ -141,7 +141,7 @@ pub fn check_domain_syntax(domain_name: &str) -> Result<(), DomainError> {
         }
         let mut bad_chars = Vec::new();
         for c in label.chars() {
-            if !c.is_ascii_alphanumeric() && !bad_chars.contains(&c) {
+            if !c.is_ascii_alphanumeric() && c != '-' && !bad_chars.contains(&c) {
                 bad_chars.push(c);
             }
         }
@@ -167,6 +167,7 @@ mod test {
     #[rstest(
         input,
         case("com.example"),
+        case("com.exa-mple"),
         case("t2900.e1.s709.t1000"),
         case("kotlin.com"),
         case("java.test"),


### PR DESCRIPTION
According to Tauri documentation V1 a hyphen is allowed in the domain name [ref](https://tauri.app/v1/api/config/#bundleconfig.identifier).