### PR TITLE
refactor!: use config.domain as package name and bundle id

### DIFF
--- a/.changes/use-tauri-identifier.md
+++ b/.changes/use-tauri-identifier.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+**BREAKING CHANGE:** Take `config.domain` as package name in Android and bundle ID in iOS instead of combining it with the libname in Cargo.toml.

--- a/.changes/use-tauri-identifier.md
+++ b/.changes/use-tauri-identifier.md
@@ -2,4 +2,8 @@
 "cargo-mobile2": minor
 ---
 
-**BREAKING CHANGE:** Take `config.domain` as package name in Android and bundle ID in iOS instead of combining it with the libname in Cargo.toml.
+Use `config.identifier` as the package name in Android and bundle ID in iOS.
+
+**BREAKING CHANGE:**
+  - In `Config`, renamed field `domain` to `identifier`.
+  - In `App`, renamed method `reverse_domain` to `reverse_identifier`.

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -359,12 +359,7 @@ impl<'a> Device<'a> {
             self.install_apk(config, env, profile)
                 .map_err(RunError::ApkInstallFailed)?;
         }
-        let activity = format!(
-            "{}.{}/{}",
-            config.app().reverse_domain(),
-            config.app().name_snake(),
-            activity
-        );
+        let activity = format!("{}/{}", config.app().reverse_domain(), activity);
         self.adb(env)
             .before_spawn(move |cmd| {
                 cmd.args(["shell", "am", "start", "-n", &activity]);
@@ -391,16 +386,7 @@ impl<'a> Device<'a> {
         let stdout = loop {
             let cmd = duct::cmd(
                 env.platform_tools_path().join("adb"),
-                [
-                    "shell",
-                    "pidof",
-                    "-s",
-                    &format!(
-                        "{}.{}",
-                        config.app().reverse_domain(),
-                        config.app().name_snake(),
-                    ),
-                ],
+                ["shell", "pidof", "-s", &config.app().reverse_domain()],
             )
             .vars(env.explicit_env())
             .stderr_capture()

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -359,7 +359,7 @@ impl<'a> Device<'a> {
             self.install_apk(config, env, profile)
                 .map_err(RunError::ApkInstallFailed)?;
         }
-        let activity = format!("{}/{}", config.app().reverse_domain(), activity);
+        let activity = format!("{}/{}", config.app().reverse_identifier(), activity);
         self.adb(env)
             .before_spawn(move |cmd| {
                 cmd.args(["shell", "am", "start", "-n", &activity]);
@@ -386,7 +386,7 @@ impl<'a> Device<'a> {
         let stdout = loop {
             let cmd = duct::cmd(
                 env.platform_tools_path().join("adb"),
-                ["shell", "pidof", "-s", &config.app().reverse_domain()],
+                ["shell", "pidof", "-s", &config.app().reverse_identifier()],
             )
             .vars(env.explicit_env())
             .stderr_capture()

--- a/src/apple/device/simctl/run.rs
+++ b/src/apple/device/simctl/run.rs
@@ -45,8 +45,7 @@ pub fn run(
 
     handle.wait().map_err(RunError::DeployFailed)?;
 
-    let app_id = format!("{}.{}", config.app().reverse_domain(), config.app().name());
-
+    let app_id = config.app().reverse_domain();
     let mut launcher_cmd = duct::cmd("xcrun", ["simctl", "launch", id, &app_id])
         .vars(env.explicit_env())
         .dup_stdio();

--- a/src/apple/device/simctl/run.rs
+++ b/src/apple/device/simctl/run.rs
@@ -45,7 +45,7 @@ pub fn run(
 
     handle.wait().map_err(RunError::DeployFailed)?;
 
-    let app_id = config.app().reverse_domain();
+    let app_id = config.app().reverse_identifier();
     let mut launcher_cmd = duct::cmd("xcrun", ["simctl", "launch", id, &app_id])
         .vars(env.explicit_env())
         .dup_stdio();

--- a/src/config/app/identifier.rs
+++ b/src/config/app/identifier.rs
@@ -70,7 +70,7 @@ static RESERVED_KEYWORDS: [&str; 63] = [
 ];
 
 #[derive(Debug)]
-pub enum DomainError {
+pub enum IdentifierError {
     Empty,
     NotAsciiAlphanumeric { bad_chars: Vec<char> },
     StartsWithDigit { label: String },
@@ -80,15 +80,15 @@ pub enum DomainError {
     EmptyLabel,
 }
 
-impl Error for DomainError {}
+impl Error for IdentifierError {}
 
-impl fmt::Display for DomainError {
+impl fmt::Display for IdentifierError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Empty => write!(f, "Domain can't be empty."),
+            Self::Empty => write!(f, "Identifier can't be empty."),
             Self::NotAsciiAlphanumeric { bad_chars } => write!(
                 f,
-                "{} characters were used in domain, but only ASCII letters and numbers are allowed.",
+                "{} characters were used in identifier, but only ASCII letters and numbers are allowed.",
                 list_display(
                     &bad_chars
                         .iter()
@@ -98,7 +98,7 @@ impl fmt::Display for DomainError {
             ),
             Self::ReservedPackageName { package_name } => write!(
                 f,
-                "\"{}\" is a reserved package name in this project and can't be used as a top-level domain.",
+                "\"{}\" is a reserved package name in this project and can't be used as a top-level identifier.",
                 package_name
             ),
             Self::ReservedKeyword { keyword } => write!(
@@ -111,31 +111,31 @@ impl fmt::Display for DomainError {
                 "\"{}\" label starts with a digit, which is not allowed in java/kotlin packages.",
                 label
             ),
-            Self::StartsOrEndsWithADot => write!(f, "Domain can't start or end with a dot."),
+            Self::StartsOrEndsWithADot => write!(f, "Identifier can't start or end with a dot."),
             Self::EmptyLabel => write!(f, "Labels can't be empty."),
         }
     }
 }
 
-pub fn check_domain_syntax(domain_name: &str) -> Result<(), DomainError> {
-    if domain_name.is_empty() {
-        return Err(DomainError::Empty);
+pub fn check_identifier_syntax(identifier_name: &str) -> Result<(), IdentifierError> {
+    if identifier_name.is_empty() {
+        return Err(IdentifierError::Empty);
     }
-    if domain_name.starts_with('.') || domain_name.ends_with('.') {
-        return Err(DomainError::StartsOrEndsWithADot);
+    if identifier_name.starts_with('.') || identifier_name.ends_with('.') {
+        return Err(IdentifierError::StartsOrEndsWithADot);
     }
-    let labels = domain_name.split('.');
+    let labels = identifier_name.split('.');
     for label in labels {
         if label.is_empty() {
-            return Err(DomainError::EmptyLabel);
+            return Err(IdentifierError::EmptyLabel);
         }
         if RESERVED_KEYWORDS.contains(&label) {
-            return Err(DomainError::ReservedKeyword {
+            return Err(IdentifierError::ReservedKeyword {
                 keyword: label.to_owned(),
             });
         }
         if label.chars().next().unwrap().is_ascii_digit() {
-            return Err(DomainError::StartsWithDigit {
+            return Err(IdentifierError::StartsWithDigit {
                 label: label.to_owned(),
             });
         }
@@ -146,12 +146,12 @@ pub fn check_domain_syntax(domain_name: &str) -> Result<(), DomainError> {
             }
         }
         if !bad_chars.is_empty() {
-            return Err(DomainError::NotAsciiAlphanumeric { bad_chars });
+            return Err(IdentifierError::NotAsciiAlphanumeric { bad_chars });
         }
     }
     for pkg_name in RESERVED_PACKAGE_NAMES.iter() {
-        if domain_name.ends_with(pkg_name) {
-            return Err(DomainError::ReservedPackageName {
+        if identifier_name.ends_with(pkg_name) {
+            return Err(IdentifierError::ReservedPackageName {
                 package_name: pkg_name.to_string(),
             });
         }
@@ -172,22 +172,22 @@ mod test {
         case("java.test"),
         case("synchronized2.com")
     )]
-    fn test_check_domain_syntax_correct(input: &str) {
-        check_domain_syntax(input).unwrap();
+    fn test_check_identifier_syntax_correct(input: &str) {
+        check_identifier_syntax(input).unwrap();
     }
 
     #[rstest(input, error,
-        case("ラスト.テスト", DomainError::NotAsciiAlphanumeric { bad_chars: vec!['ラ', 'ス', 'ト'] }),
-        case("test.digits.87", DomainError::StartsWithDigit { label: String::from("87") }),
-        case("", DomainError::Empty {}),
-        case(".bad.dot.syntax", DomainError::StartsOrEndsWithADot {}),
-        case("com.kotlin", DomainError::ReservedPackageName { package_name: String::from("kotlin") }),
-        case("some.domain.catch.com", DomainError::ReservedKeyword { keyword: String::from("catch") }),
-        case("com..empty.label", DomainError::EmptyLabel)
+        case("ラスト.テスト", IdentifierError::NotAsciiAlphanumeric { bad_chars: vec!['ラ', 'ス', 'ト'] }),
+        case("test.digits.87", IdentifierError::StartsWithDigit { label: String::from("87") }),
+        case("", IdentifierError::Empty {}),
+        case(".bad.dot.syntax", IdentifierError::StartsOrEndsWithADot {}),
+        case("com.kotlin", IdentifierError::ReservedPackageName { package_name: String::from("kotlin") }),
+        case("some.identifier.catch.com", IdentifierError::ReservedKeyword { keyword: String::from("catch") }),
+        case("com..empty.label", IdentifierError::EmptyLabel)
     )]
-    fn test_check_domain_syntax_error(input: &str, error: DomainError) {
+    fn test_check_identifier_syntax_error(input: &str, error: IdentifierError) {
         assert_eq!(
-            check_domain_syntax(input).unwrap_err().to_string(),
+            check_identifier_syntax(input).unwrap_err().to_string(),
             error.to_string()
         )
     }

--- a/src/config/app/mod.rs
+++ b/src/config/app/mod.rs
@@ -1,5 +1,5 @@
 mod common_email_providers;
-pub mod domain;
+pub mod identifier;
 pub mod lib_name;
 pub mod name;
 mod raw;
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("`app.identifier` {identifier} isn't valid: {cause}")]
     IdentifierInvalid {
         identifier: String,
-        cause: domain::DomainError,
+        cause: identifier::IdentifierError,
     },
     #[error("`app.asset-dir` {asset_dir} couldn't be normalized: {cause}")]
     AssetDirNormalizationFailed {
@@ -104,7 +104,7 @@ impl App {
 
         let identifier = {
             let identifier = raw.identifier;
-            domain::check_domain_syntax(&identifier)
+            identifier::check_identifier_syntax(&identifier)
                 .map_err(|cause| Error::IdentifierInvalid {
                     identifier: identifier.clone(),
                     cause,

--- a/src/config/app/mod.rs
+++ b/src/config/app/mod.rs
@@ -35,9 +35,9 @@ pub enum Error {
     NameInvalid(name::Invalid),
     #[error("app.lib_name invalid: {0}")]
     LibNameInvalid(lib_name::Invalid),
-    #[error("`app.domain` {domain} isn't valid: {cause}")]
-    DomainInvalid {
-        domain: String,
+    #[error("`app.identifier` {identifier} isn't valid: {cause}")]
+    IdentifierInvalid {
+        identifier: String,
         cause: domain::DomainError,
     },
     #[error("`app.asset-dir` {asset_dir} couldn't be normalized: {cause}")]
@@ -67,7 +67,7 @@ pub struct App {
     name: String,
     lib_name: Option<String>,
     stylized_name: String,
-    domain: String,
+    identifier: String,
     asset_dir: PathBuf,
     #[serde(skip)]
     template_pack: Pack,
@@ -82,7 +82,7 @@ impl Debug for App {
             .field("root_dir", &self.root_dir)
             .field("name", &self.name)
             .field("stylized_name", &self.stylized_name)
-            .field("domain", &self.domain)
+            .field("identifier", &self.identifier)
             .field("asset_dir", &self.asset_dir)
             .field("template_pack", &self.template_pack)
             .finish()
@@ -102,14 +102,14 @@ impl App {
 
         let stylized_name = raw.stylized_name.unwrap_or_else(|| name.clone());
 
-        let domain = {
-            let domain = raw.domain;
-            domain::check_domain_syntax(&domain)
-                .map_err(|cause| Error::DomainInvalid {
-                    domain: domain.clone(),
+        let identifier = {
+            let identifier = raw.identifier;
+            domain::check_domain_syntax(&identifier)
+                .map_err(|cause| Error::IdentifierInvalid {
+                    identifier: identifier.clone(),
                     cause,
                 })
-                .map(|()| domain)
+                .map(|()| identifier)
         }?;
 
         if raw.asset_dir.as_deref() == Some(DEFAULT_ASSET_DIR) {
@@ -156,7 +156,7 @@ impl App {
             name,
             lib_name,
             stylized_name,
-            domain,
+            identifier,
             asset_dir,
             template_pack,
             target_dir_resolver: None,
@@ -213,8 +213,8 @@ impl App {
         &self.stylized_name
     }
 
-    pub fn reverse_domain(&self) -> String {
-        self.domain
+    pub fn reverse_identifier(&self) -> String {
+        self.identifier
             .clone()
             .split('.')
             .rev()

--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -14,31 +14,32 @@ use std::{
 };
 
 #[derive(Debug)]
-enum DefaultDomainError {
+enum DefaultIdentifierError {
     FailedToGetGitEmailAddr(#[allow(unused)] std::io::Error),
     FailedToParseEmailAddr,
 }
 
-fn default_domain(_wrapper: &TextWrapper) -> Result<Option<String>, DefaultDomainError> {
+fn default_identifier(_wrapper: &TextWrapper) -> Result<Option<String>, DefaultIdentifierError> {
     let email = Git::new(".".as_ref())
         .user_email()
-        .map_err(DefaultDomainError::FailedToGetGitEmailAddr)?;
-    let domain = email
+        .map_err(DefaultIdentifierError::FailedToGetGitEmailAddr)?;
+    let identifier = email
         .trim()
         .split('@')
         .last()
-        .ok_or(DefaultDomainError::FailedToParseEmailAddr)?;
+        .ok_or(DefaultIdentifierError::FailedToParseEmailAddr)?;
     Ok(
-        if !COMMON_EMAIL_PROVIDERS.contains(&domain) && domain::check_domain_syntax(domain).is_ok()
+        if !COMMON_EMAIL_PROVIDERS.contains(&identifier)
+            && domain::check_domain_syntax(identifier).is_ok()
         {
             #[cfg(not(feature = "brainium"))]
-            if domain == "brainiumstudios.com" {
+            if identifier == "brainiumstudios.com" {
                 crate::util::cli::Report::action_request(
                     "You have a Brainium email address, but you're using a non-Brainium installation of cargo-mobile2!",
                     "If that's not intentional, run `cargo install --force --git https://github.com/tauri-apps/cargo-mobile2 --features brainium`",
                 ).print(_wrapper);
             }
-            Some(domain.to_owned())
+            Some(identifier.to_owned())
         } else {
             None
         },
@@ -74,7 +75,7 @@ impl Display for DefaultsError {
 struct Defaults {
     name: Option<String>,
     stylized_name: String,
-    domain: String,
+    identifier: String,
 }
 
 impl Defaults {
@@ -89,7 +90,7 @@ impl Defaults {
         Ok(Self {
             name: name::transliterate(&dir_name.to_kebab_case()),
             stylized_name: dir_name.to_title_case(),
-            domain: default_domain(wrapper)
+            identifier: default_identifier(wrapper)
                 .ok()
                 .flatten()
                 .unwrap_or_else(|| "example.com".to_owned()),
@@ -117,7 +118,7 @@ pub enum PromptError {
     DefaultsFailed(DefaultsError),
     NamePromptFailed(io::Error),
     StylizedNamePromptFailed(io::Error),
-    DomainPromptFailed(io::Error),
+    IdentifierPromptFailed(io::Error),
     ListTemplatePacksFailed(templating::ListError),
     TemplatePackPromptFailed(io::Error),
 }
@@ -130,7 +131,9 @@ impl Display for PromptError {
             Self::StylizedNamePromptFailed(err) => {
                 write!(f, "Failed to prompt for stylized name: {}", err)
             }
-            Self::DomainPromptFailed(err) => write!(f, "Failed to prompt for domain: {}", err),
+            Self::IdentifierPromptFailed(err) => {
+                write!(f, "Failed to prompt for identifier: {}", err)
+            }
             Self::ListTemplatePacksFailed(err) => write!(f, "{}", err),
             Self::TemplatePackPromptFailed(err) => {
                 write!(f, "Failed to prompt for template pack: {}", err)
@@ -145,7 +148,7 @@ pub struct Raw {
     pub name: String,
     pub lib_name: Option<String>,
     pub stylized_name: Option<String>,
-    pub domain: String,
+    pub identifier: String,
     pub asset_dir: Option<String>,
     pub template_pack: Option<String>,
 }
@@ -157,7 +160,7 @@ impl Raw {
             name: defaults.name.ok_or_else(|| DetectError::NameNotDetected)?,
             lib_name: None,
             stylized_name: Some(defaults.stylized_name),
-            domain: defaults.domain,
+            identifier: defaults.identifier,
             asset_dir: None,
             template_pack: Some(super::DEFAULT_TEMPLATE_PACK.to_owned())
                 .filter(|pack| pack != super::IMPLIED_TEMPLATE_PACK),
@@ -168,14 +171,14 @@ impl Raw {
         let defaults = Defaults::new(wrapper).map_err(PromptError::DefaultsFailed)?;
         let (name, default_stylized) = Self::prompt_name(wrapper, &defaults)?;
         let stylized_name = Self::prompt_stylized_name(&name, default_stylized)?;
-        let domain = Self::prompt_domain(wrapper, &defaults)?;
+        let identifier = Self::prompt_identifier(wrapper, &defaults)?;
         let template_pack = Some(Self::prompt_template_pack(wrapper)?)
             .filter(|pack| pack != super::IMPLIED_TEMPLATE_PACK);
         Ok(Self {
             name,
             lib_name: None,
             stylized_name: Some(stylized_name),
-            domain,
+            identifier,
             asset_dir: None,
             template_pack,
         })
@@ -231,10 +234,13 @@ impl Raw {
             .map_err(PromptError::StylizedNamePromptFailed)
     }
 
-    fn prompt_domain(wrapper: &TextWrapper, defaults: &Defaults) -> Result<String, PromptError> {
+    fn prompt_identifier(
+        wrapper: &TextWrapper,
+        defaults: &Defaults,
+    ) -> Result<String, PromptError> {
         Ok(loop {
-            let response = prompt::default("Domain", Some(&defaults.domain), None)
-                .map_err(PromptError::DomainPromptFailed)?;
+            let response = prompt::default("Identifier", Some(&defaults.identifier), None)
+                .map_err(PromptError::IdentifierPromptFailed)?;
             match domain::check_domain_syntax(response.as_str()) {
                 Ok(_) => break response,
                 Err(err) => {

--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -1,4 +1,4 @@
-use super::{common_email_providers::COMMON_EMAIL_PROVIDERS, domain, name};
+use super::{common_email_providers::COMMON_EMAIL_PROVIDERS, identifier, name};
 use crate::{
     templating,
     util::{cli::TextWrapper, prompt, Git},
@@ -30,7 +30,7 @@ fn default_identifier(_wrapper: &TextWrapper) -> Result<Option<String>, DefaultI
         .ok_or(DefaultIdentifierError::FailedToParseEmailAddr)?;
     Ok(
         if !COMMON_EMAIL_PROVIDERS.contains(&identifier)
-            && domain::check_domain_syntax(identifier).is_ok()
+            && identifier::check_identifier_syntax(identifier).is_ok()
         {
             #[cfg(not(feature = "brainium"))]
             if identifier == "brainiumstudios.com" {
@@ -241,7 +241,7 @@ impl Raw {
         Ok(loop {
             let response = prompt::default("Identifier", Some(&defaults.identifier), None)
                 .map_err(PromptError::IdentifierPromptFailed)?;
-            match domain::check_domain_syntax(response.as_str()) {
+            match identifier::check_identifier_syntax(response.as_str()) {
                 Ok(_) => break response,
                 Err(err) => {
                     println!(

--- a/src/templating/fancy.rs
+++ b/src/templating/fancy.rs
@@ -68,7 +68,7 @@ impl FancyPack {
             .map(|p| p.join(&raw.path))
             .unwrap_or(raw.path.clone());
 
-        let real_path = util::expand_home(&raw_path).map_err(FancyPackParseError::NoHomeDir)?;
+        let real_path = util::expand_home(raw_path).map_err(FancyPackParseError::NoHomeDir)?;
         let this = Self {
             path: real_path,
             base: raw

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -9,8 +9,8 @@ pub fn minimal(msg: impl Display) -> io::Result<String> {
     print!("{}: ", msg);
     io::stdout().flush()?;
     io::stdin().read_line(&mut input)?;
-    input = input.trim().to_owned();
-    Ok(input)
+
+    Ok(input.trim().to_owned())
 }
 
 pub fn default(

--- a/templates/apps/wry/Cargo.toml.hbs
+++ b/templates/apps/wry/Cargo.toml.hbs
@@ -12,7 +12,7 @@ name = "{{app.name}}-desktop"
 path = "gen/bin/desktop.rs"
 
 [package.metadata.cargo-android]
-app-activity-name = "{{reverse-domain app.domain}}.MainActivity"
+app-activity-name = "{{reverse-domain app.identifier}}.MainActivity"
 app-dependencies = [
     "androidx.webkit:webkit:1.6.1",
     "androidx.appcompat:appcompat:1.6.1",
@@ -25,9 +25,9 @@ app-theme-parent = "Theme.MaterialComponents.DayNight.DarkActionBar"
 vulkan-validation = false
 
 [package.metadata.cargo-android.env-vars]
-WRY_ANDROID_PACKAGE = "{{reverse-domain app.domain}}"
+WRY_ANDROID_PACKAGE = "{{reverse-domain app.identifier}}"
 WRY_ANDROID_LIBRARY = "{{snake-case app.name}}"
-WRY_ANDROID_KOTLIN_FILES_OUT_DIR = "<android-project-dir>/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}"
+WRY_ANDROID_KOTLIN_FILES_OUT_DIR = "<android-project-dir>/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.identifier)}}"
 
 [package.metadata.cargo-apple.ios]
 frameworks = [ "WebKit" ]

--- a/templates/apps/wry/Cargo.toml.hbs
+++ b/templates/apps/wry/Cargo.toml.hbs
@@ -12,7 +12,7 @@ name = "{{app.name}}-desktop"
 path = "gen/bin/desktop.rs"
 
 [package.metadata.cargo-android]
-app-activity-name = "{{reverse-domain app.domain}}.{{snake-case app.name}}.MainActivity"
+app-activity-name = "{{reverse-domain app.domain}}.MainActivity"
 app-dependencies = [
     "androidx.webkit:webkit:1.6.1",
     "androidx.appcompat:appcompat:1.6.1",
@@ -25,7 +25,7 @@ app-theme-parent = "Theme.MaterialComponents.DayNight.DarkActionBar"
 vulkan-validation = false
 
 [package.metadata.cargo-android.env-vars]
-WRY_ANDROID_PACKAGE = "{{reverse-domain app.domain}}.{{snake-case app.name}}"
+WRY_ANDROID_PACKAGE = "{{reverse-domain app.domain}}"
 WRY_ANDROID_LIBRARY = "{{snake-case app.name}}"
 WRY_ANDROID_KOTLIN_FILES_OUT_DIR = "<android-project-dir>/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}"
 

--- a/templates/apps/wry/gen/android/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}/MainActivity.kt.hbs
+++ b/templates/apps/wry/gen/android/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}/MainActivity.kt.hbs
@@ -1,3 +1,3 @@
-package {{reverse-domain app.domain}}.{{snake-case app.name}}
+package {{reverse-domain app.domain}}
 
 class MainActivity : WryActivity()

--- a/templates/apps/wry/gen/android/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}/MainActivity.kt.hbs
+++ b/templates/apps/wry/gen/android/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}/MainActivity.kt.hbs
@@ -1,3 +1,3 @@
-package {{reverse-domain app.domain}}
+package {{reverse-domain app.identifier}}
 
 class MainActivity : WryActivity()

--- a/templates/apps/wry/src/lib.rs.hbs
+++ b/templates/apps/wry/src/lib.rs.hbs
@@ -43,7 +43,6 @@ pub extern "C" fn start_app() {
     {
         tao::android_binding!(
             {{reverse-domain-snake-case app.domain}},
-            {{snake-case app.name}},
             WryActivity,
             wry::android_setup, // pass the wry::android_setup function to tao which will invoke when the event loop is created
             _start_app

--- a/templates/apps/wry/src/lib.rs.hbs
+++ b/templates/apps/wry/src/lib.rs.hbs
@@ -42,7 +42,7 @@ pub extern "C" fn start_app() {
     #[cfg(target_os = "android")]
     {
         tao::android_binding!(
-            {{reverse-domain-snake-case app.domain}},
+            {{reverse-domain-snake-case app.identifier}},
             WryActivity,
             wry::android_setup, // pass the wry::android_setup function to tao which will invoke when the event loop is created
             _start_app

--- a/templates/platforms/android-studio/app/build.gradle.kts.hbs
+++ b/templates/platforms/android-studio/app/build.gradle.kts.hbs
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    namespace="{{reverse-domain app.domain}}.{{snake-case app.name}}"{{#if has-asset-packs}}
+    namespace="{{reverse-domain app.identifier}}"{{#if has-asset-packs}}
     assetPacks += mutableSetOf({{quote-and-join-colon-prefix asset-packs}}){{/if}}
     compileSdk = 33
     defaultConfig {
-        applicationId = "{{reverse-domain app.domain}}.{{snake-case app.name}}"
+        applicationId = "{{reverse-domain app.identifier}}"
         minSdk = {{android.min-sdk-version}}
         targetSdk = 33
         versionCode = 1

--- a/templates/platforms/xcode/project.yml.hbs
+++ b/templates/platforms/xcode/project.yml.hbs
@@ -1,6 +1,6 @@
 name: {{app.name}}
 options:
-  bundleIdPrefix: {{reverse-domain app.domain}}
+  bundleIdPrefix: {{reverse-domain app.identifier}}
   deploymentTarget:
     iOS: {{apple.ios-version}}
     macOS: {{apple.macos-version}}
@@ -12,7 +12,7 @@ settingGroups:
   app:
     base:
       PRODUCT_NAME: {{app.stylized-name}}
-      PRODUCT_BUNDLE_IDENTIFIER: {{reverse-domain app.domain}}.{{app.name}}
+      PRODUCT_BUNDLE_IDENTIFIER: {{reverse-domain app.identifier}}
       {{#if apple.development-team}}
       DEVELOPMENT_TEAM: {{apple.development-team}}
       {{/if}}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(android): fix emulator detection
    - docs: update docstrings
    - feat: add new mobile template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->

Ref: https://github.com/tauri-apps/tauri/issues/9851

**BREAKING CHANGE:**
Will use `config.domain` as `Package Name` in Android and `BundleId` in iOS.
Before: `config.domain` + libname in Cargo.toml

If we are going to change the behavior, maybe changing the variable `domain` to `identifier` will be better?
