### PR TITLE
feat: Add a Dioxus template

### DIFF
--- a/templates/apps/dioxus/.gitignore.hbs
+++ b/templates/apps/dioxus/.gitignore.hbs
@@ -1,0 +1,10 @@
+# Rust
+target/
+**/*.rs.bk
+
+# cargo-mobile2
+.cargo/
+/gen
+
+# macOS
+.DS_Store

--- a/templates/apps/dioxus/Cargo.toml.hbs
+++ b/templates/apps/dioxus/Cargo.toml.hbs
@@ -1,0 +1,51 @@
+[package]
+name = "{{app.name}}"
+version = "0.1.0"
+authors = ["{{author}}"]
+edition = "2018"
+
+[lib]
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[[bin]]
+name = "{{app.name}}-desktop"
+path = "gen/bin/desktop.rs"
+
+[package.metadata.cargo-android]
+app-activity-name = "{{reverse-domain app.identifier}}.MainActivity"
+app-dependencies = [
+    "androidx.webkit:webkit:1.6.1",
+    "androidx.appcompat:appcompat:1.6.1",
+    "com.google.android.material:material:1.8.0",
+]
+project-dependencies = [ "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21" ]
+app-plugins = [ "org.jetbrains.kotlin.android" ]
+app-permissions = [ "android.permission.INTERNET" ]
+app-theme-parent = "Theme.MaterialComponents.DayNight.DarkActionBar"
+vulkan-validation = false
+
+[package.metadata.cargo-android.env-vars]
+WRY_ANDROID_PACKAGE = "{{reverse-domain app.identifier}}"
+WRY_ANDROID_LIBRARY = "{{snake-case app.name}}"
+WRY_ANDROID_KOTLIN_FILES_OUT_DIR = "<android-project-dir>/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.identifier)}}"
+
+[package.metadata.cargo-apple.ios]
+frameworks = [ "WebKit" ]
+
+[dependencies]
+anyhow = "1.0"
+log = "0.4"
+wry = "0.37"
+tao = "0.26"
+dioxus = { version = "0.6.0-alpha.2", features = ["mobile"] }
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.13"
+jni = "0.21.0"
+paste = "1.0"
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+env_logger = "0.9.0"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+core-foundation = "0.9.3"

--- a/templates/apps/dioxus/README.md
+++ b/templates/apps/dioxus/README.md
@@ -1,0 +1,9 @@
+# Dioxus
+
+## iOS
+
+Must run Xcode on rosetta. Goto Application > Right Click Xcode > Get Info > Open in Rosetta.
+
+If you are using M1, you will have to run `cargo build --target x86_64-apple-ios` instead of `cargo apple build` if you want to run in simulator.
+
+Otherwise, it's all `cargo apple run` when running in actual device.

--- a/templates/apps/dioxus/gen/android/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}/MainActivity.kt.hbs
+++ b/templates/apps/dioxus/gen/android/app/src/main/kotlin/{{dot-to-slash (reverse-domain app.domain)}}/{{snake-case app.name}}/MainActivity.kt.hbs
@@ -1,0 +1,3 @@
+package {{escape-kotlin-keyword (reverse-domain app.identifier)}}
+
+class MainActivity : WryActivity()

--- a/templates/apps/dioxus/gen/bin/desktop.rs.hbs
+++ b/templates/apps/dioxus/gen/bin/desktop.rs.hbs
@@ -1,0 +1,5 @@
+
+fn main() {
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    {{snake-case app.name}}::main();
+}

--- a/templates/apps/dioxus/src/lib.rs.hbs
+++ b/templates/apps/dioxus/src/lib.rs.hbs
@@ -1,0 +1,83 @@
+use dioxus::prelude::*;
+
+#[cfg(target_os = "android")]
+fn init_logging() {
+    android_logger::init_once(
+        android_logger::Config::default()
+            .with_max_level(log::LevelFilter::Trace)
+            .with_tag("{{app.name}}"),
+    );
+}
+
+#[cfg(not(target_os = "android"))]
+fn init_logging() {
+    env_logger::init();
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn stop_unwind<F: FnOnce() -> T, T>(f: F) -> T {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(t) => t,
+        Err(err) => {
+            eprintln!("attempt to unwind out of `rust` with err: {:?}", err);
+            std::process::abort()
+        }
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn _start_app() {
+    stop_unwind(|| main());
+}
+
+#[no_mangle]
+#[inline(never)]
+#[cfg(any(target_os = "android", target_os = "ios"))]
+pub extern "C" fn start_app() {
+    #[cfg(target_os = "android")]
+    {
+        tao::android_binding!(
+            {{reverse-domain-snake-case app.identifier}},
+            WryActivity,
+            wry::android_setup, // pass the wry::android_setup function to tao which will invoke when the event loop is created
+            _start_app
+        );
+        wry::android_binding!(com_example, {{snake-case app.name}});
+    }
+
+    #[cfg(target_os = "ios")]
+    _start_app()
+}
+
+pub fn main() {
+    init_logging();
+    
+    dioxus::launch(app);
+}
+
+fn app() -> Element {
+    let mut items = use_signal(|| vec![1, 2, 3]);
+
+    log::debug!("Hello from the app");
+
+    rsx! {
+        div {
+            h1 { "Hello, Mobile"}
+            div { margin_left: "auto", margin_right: "auto", width: "200px", padding: "10px", border: "1px solid black",
+                button {
+                    onclick: move|_| {
+                        println!("Clicked!");
+                        let mut items_mut = items.write();
+                        let new_item = items_mut.len() + 1;
+                        items_mut.push(new_item);
+                        println!("Requested update");
+                    },
+                    "Add item"
+                }
+                for item in items.read().iter() {
+                    div { "- {item}" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a template to initialize new [Dioxus](https://github.com/DioxusLabs/dioxus) apps (based on the `wry` template) using `dioxus-mobile` 😄 

```
$ cargo mobile new my_app
  Project name (my_app): 
  Stylized name (MyApp): 
  Identifier (dioxuslabs.com): 
  Detected template packs:
    [0] bevy
    [1] bevy-demo
    [2] dioxus
    [3] egui
    [4] wgpu
    [5] winit
    [6] wry
    Enter an index for a template pack above.
```

This currently uses Dioxus `v0.6.0-alpha.2` but we'd like to push an update as soon as `v0.6.0` is stable.