### PR TITLE
feat(apple): add config to allow provisoning updates

### DIFF
--- a/.changes/apple-export-config.md
+++ b/.changes/apple-export-config.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+Added a `ExportConfig` argument to the `Target::export` iOS method to allow provisioning updates.

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -4,6 +4,7 @@ use super::{
     target::{ArchiveError, BuildError, ExportError, Target},
 };
 use crate::{
+    apple::target::ExportConfig,
     env::{Env, ExplicitEnv as _},
     opts,
     util::cli::{Report, Reportable},
@@ -140,7 +141,7 @@ impl<'a> Device<'a> {
             DeviceKind::IosDeployDevice | DeviceKind::DeviceCtlDevice => {
                 println!("Exporting app...");
                 self.target
-                    .export(config, env, noise_level)
+                    .export(config, env, noise_level, ExportConfig::default())
                     .map_err(RunError::ExportFailed)?;
                 println!("Extracting IPA...");
 


### PR DESCRIPTION
changes the Target::export method to be configurable, adding options to allow provisioning updates - which means code signing certificates and provisioning profiles are managed by xcodebuild (with API key config for CI authentication)

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(android): fix emulator detection
    - docs: update docstrings
    - feat: add new mobile template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
