### PR TITLE
chore(android): no longer needs to search the .cargo folder for links

### DIFF
--- a/.changes/android-rustflags.md
+++ b/.changes/android-rustflags.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+The Rust flags for Android builds no longer need to search the .cargo folder for libraries.

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -213,10 +213,6 @@ impl<'a> Target<'a> {
             linker: Some(linker),
             rustflags: vec![
                 "-L".to_owned(),
-                format!(
-                    "\"{}\"",
-                    dunce::simplified(&config.app().prefix_path(".cargo")).display()
-                ),
                 "-Clink-arg=-landroid".to_owned(),
                 "-Clink-arg=-llog".to_owned(),
                 "-Clink-arg=-lOpenSLES".to_owned(),


### PR DESCRIPTION
ref #125
