### PR TITLE
feat(apple): allow provisioning updates for Target::build

### DIFF
--- a/.changes/apple-build-options.md
+++ b/.changes/apple-build-options.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+Added a `BuildConfig` argument to the `Target::build` iOS method to allow provisioning updates.

--- a/.changes/move-auth-credentials.md
+++ b/.changes/move-auth-credentials.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+Move `AuthCredentials` to `cargo_mobile2::apple`.

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -3,7 +3,9 @@ use crate::{
         config::{Config, Metadata},
         device::{self, Device, RunError},
         rust_version_check,
-        target::{ArchiveError, BuildError, CheckError, CompileLibError, ExportError, Target},
+        target::{
+            ArchiveError, BuildConfig, BuildError, CheckError, CompileLibError, ExportError, Target,
+        },
         NAME,
     },
     config::{
@@ -314,7 +316,13 @@ impl Exec for Input {
                     &env,
                     |target: &Target| {
                         target
-                            .build(config, &env, noise_level, profile)
+                            .build(
+                                config,
+                                &env,
+                                noise_level,
+                                profile,
+                                BuildConfig::default().allow_provisioning_updates(),
+                            )
                             .map_err(Error::BuildFailed)
                     },
                 )
@@ -338,7 +346,13 @@ impl Exec for Input {
                         }
 
                         target
-                            .build(config, &env, noise_level, profile)
+                            .build(
+                                config,
+                                &env,
+                                noise_level,
+                                profile,
+                                BuildConfig::new().allow_provisioning_updates(),
+                            )
                             .map_err(Error::BuildFailed)?;
                         target
                             .archive(config, &env, noise_level, profile, Some(app_version))

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -4,7 +4,7 @@ use super::{
     target::{ArchiveError, BuildError, ExportError, Target},
 };
 use crate::{
-    apple::target::ExportConfig,
+    apple::target::{BuildConfig, ExportConfig},
     env::{Env, ExplicitEnv as _},
     opts,
     util::cli::{Report, Reportable},
@@ -128,7 +128,13 @@ impl<'a> Device<'a> {
         // TODO: These steps are run unconditionally, which is slooooooow
         println!("Building app...");
         self.target
-            .build(config, env, noise_level, profile)
+            .build(
+                config,
+                env,
+                noise_level,
+                profile,
+                BuildConfig::new().allow_provisioning_updates(),
+            )
             .map_err(RunError::BuildFailed)?;
         println!("Archiving app...");
         self.target
@@ -141,7 +147,12 @@ impl<'a> Device<'a> {
             DeviceKind::IosDeployDevice | DeviceKind::DeviceCtlDevice => {
                 println!("Exporting app...");
                 self.target
-                    .export(config, env, noise_level, ExportConfig::default())
+                    .export(
+                        config,
+                        env,
+                        noise_level,
+                        ExportConfig::default().allow_provisioning_updates(),
+                    )
                     .map_err(RunError::ExportFailed)?;
                 println!("Extracting IPA...");
 

--- a/src/apple/mod.rs
+++ b/src/apple/mod.rs
@@ -9,12 +9,21 @@ pub mod target;
 pub mod teams;
 mod version_number;
 
+use std::path::PathBuf;
+
 use crate::util::{
     self,
     cli::{Report, TextWrapper},
 };
 
 pub static NAME: &str = "apple";
+
+#[derive(Clone)]
+pub struct AuthCredentials {
+    pub key_path: PathBuf,
+    pub key_id: String,
+    pub key_issuer_id: String,
+}
 
 pub fn rust_version_check(wrapper: &TextWrapper) -> Result<(), util::RustVersionError> {
     util::RustVersion::check().map(|version| if !version.valid() {


### PR DESCRIPTION
follow up for #371, turns out in CI we also need to provide the values for the target.build() usage
