### PR TITLE
fix(apple): allow skipping code signing

### DIFF
--- a/.changes/archive-config.md
+++ b/.changes/archive-config.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+Added an `ArchiveConfig` parameter to `apple::Target::archive`.

--- a/.changes/fix-ios-automatic-signing-multiple.md
+++ b/.changes/fix-ios-automatic-signing-multiple.md
@@ -1,0 +1,7 @@
+---
+"cargo-mobile2": minor
+---
+
+Allow skipping code signing on `Apple::Target` `build` and `archive` methods,
+which fixes an issue in CI where automatic signing only works on the first execution,
+and following runs errors with `Revoke certificate: Your account already has a signing certificate for this machine but it is not present in your keychain`.

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -4,7 +4,8 @@ use crate::{
         device::{self, Device, RunError},
         rust_version_check,
         target::{
-            ArchiveError, BuildConfig, BuildError, CheckError, CompileLibError, ExportError, Target,
+            ArchiveConfig, ArchiveError, BuildConfig, BuildError, CheckError, CompileLibError,
+            ExportError, Target,
         },
         NAME,
     },
@@ -355,7 +356,14 @@ impl Exec for Input {
                             )
                             .map_err(Error::BuildFailed)?;
                         target
-                            .archive(config, &env, noise_level, profile, Some(app_version))
+                            .archive(
+                                config,
+                                &env,
+                                noise_level,
+                                profile,
+                                Some(app_version),
+                                ArchiveConfig::new().allow_provisioning_updates(),
+                            )
                             .map_err(Error::ArchiveFailed)
                     },
                 )

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -4,7 +4,7 @@ use super::{
     target::{ArchiveError, BuildError, ExportError, Target},
 };
 use crate::{
-    apple::target::{BuildConfig, ExportConfig},
+    apple::target::{ArchiveConfig, BuildConfig, ExportConfig},
     env::{Env, ExplicitEnv as _},
     opts,
     util::cli::{Report, Reportable},
@@ -138,7 +138,14 @@ impl<'a> Device<'a> {
             .map_err(RunError::BuildFailed)?;
         println!("Archiving app...");
         self.target
-            .archive(config, env, noise_level, profile, None)
+            .archive(
+                config,
+                env,
+                noise_level,
+                profile,
+                None,
+                ArchiveConfig::new(),
+            )
             .map_err(RunError::ArchiveFailed)?;
 
         match self.kind {


### PR DESCRIPTION
Looks like Apple cannot handle development profile automatic provisioning well.. let's add an option to skip codesigning for build() and archive(), and let the export() function handle signing when distributing on CI (note that with this change it should also be possible to skip code signing on all steps and sign manually later)