### PR TITLE
feat(apple): enhance log output

### DIFF
--- a/.changes/enhance-apple-log.md
+++ b/.changes/enhance-apple-log.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Only display logs from the actual iOS application unless pedantic verbosity is requested.

--- a/.changes/ios-build-logs.md
+++ b/.changes/ios-build-logs.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Always use verbose logging when building the app on iOS (`Target::build`) to display cargo build output.

--- a/src/apple/device/ios_deploy/run.rs
+++ b/src/apple/device/ios_deploy/run.rs
@@ -1,6 +1,7 @@
 use crate::{
     apple::config::Config,
     env::{Env, ExplicitEnv as _},
+    opts::NoiseLevel,
     util::cli::{Report, Reportable},
     DuctExpressionExt,
 };
@@ -25,6 +26,7 @@ pub fn run_and_debug(
     env: &Env,
     non_interactive: bool,
     id: &str,
+    noise_level: NoiseLevel,
 ) -> Result<duct::Handle, RunAndDebugError> {
     println!("Deploying app to device...");
 
@@ -50,7 +52,18 @@ pub fn run_and_debug(
             .map_err(RunAndDebugError::DeployFailed)?
             .wait()
             .map_err(RunAndDebugError::DeployFailed)?;
-        duct::cmd("idevicesyslog", ["--process", config.app().stylized_name()])
+
+        let app_name = config.app().stylized_name().to_string();
+
+        duct::cmd("idevicesyslog", ["--process", &app_name])
+            .before_spawn(move |cmd| {
+                if !noise_level.pedantic() {
+                    // when not in pedantic log mode, filter out logs that are not from the actual app
+                    // e.g. `App Name(UIKitCore)[processID]: message` vs `App Name[processID]: message`
+                    cmd.arg("--match").arg(format!("{app_name}["));
+                }
+                Ok(())
+            })
             .vars(env.explicit_env())
             .dup_stdio()
             .start()

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -149,8 +149,10 @@ impl<'a> Device<'a> {
             .map_err(RunError::ArchiveFailed)?;
 
         match self.kind {
-            DeviceKind::Simulator => simctl::run(config, env, non_interactive, &self.id)
-                .map_err(|e| RunError::DeployFailed(e.to_string())),
+            DeviceKind::Simulator => {
+                simctl::run(config, env, non_interactive, noise_level, &self.id)
+                    .map_err(|e| RunError::DeployFailed(e.to_string()))
+            }
             DeviceKind::IosDeployDevice | DeviceKind::DeviceCtlDevice => {
                 println!("Exporting app...");
                 self.target
@@ -181,11 +183,18 @@ impl<'a> Device<'a> {
                 cmd.run().map_err(RunError::UnzipFailed)?;
 
                 if self.kind == DeviceKind::IosDeployDevice {
-                    ios_deploy::run_and_debug(config, env, non_interactive, &self.id)
+                    ios_deploy::run_and_debug(config, env, non_interactive, &self.id, noise_level)
                         .map_err(|e| RunError::DeployFailed(e.to_string()))
                 } else {
-                    devicectl::run(config, env, non_interactive, &self.id, self.paired)
-                        .map_err(|e| RunError::DeployFailed(e.to_string()))
+                    devicectl::run(
+                        config,
+                        env,
+                        non_interactive,
+                        &self.id,
+                        self.paired,
+                        noise_level,
+                    )
+                    .map_err(|e| RunError::DeployFailed(e.to_string()))
                 }
             }
         }

--- a/src/apple/device/simctl/run.rs
+++ b/src/apple/device/simctl/run.rs
@@ -1,6 +1,7 @@
 use crate::{
     apple::config::Config,
     env::{Env, ExplicitEnv as _},
+    opts::NoiseLevel,
     util::cli::{Report, Reportable},
     DuctExpressionExt,
 };
@@ -24,6 +25,7 @@ pub fn run(
     config: &Config,
     env: &Env,
     non_interactive: bool,
+    noise_level: NoiseLevel,
     id: &str,
 ) -> Result<duct::Handle, RunError> {
     println!("Deploying app to device...");
@@ -76,7 +78,11 @@ pub fn run(
                 "--level",
                 "debug",
                 "--predicate",
-                &format!("process == \"{}\"", config.app().stylized_name()),
+                &if noise_level.pedantic() {
+                    format!("process == \"{}\"", config.app().stylized_name())
+                } else {
+                    format!("subsystem = \"{}\"", config.app().identifier())
+                },
             ],
         )
         .vars(env.explicit_env())

--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -426,7 +426,7 @@ impl<'a> Target<'a> {
         &self,
         config: &Config,
         env: &Env,
-        noise_level: opts::NoiseLevel,
+        _noise_level: opts::NoiseLevel,
         profile: opts::Profile,
         build_config: BuildConfig,
     ) -> Result<(), BuildError> {
@@ -446,9 +446,6 @@ impl<'a> Target<'a> {
             .before_spawn(move |cmd| {
                 build_config.xcodebuild_options.args_for(cmd);
 
-                if let Some(v) = verbosity(noise_level) {
-                    cmd.arg(v);
-                }
                 if let Some(a) = &arch {
                     cmd.args(["-arch", a]);
                 }


### PR DESCRIPTION
- always use verbose output when running `xcodebuild build` to show cargo output
- enhance simulator and device run output by only displaying app logs by default, and printing full process logs when pedantic verbosity is requested
