### PR TITLE
fix(cargo-mobile doctor): Use the correct path for detecting the sdk

### DIFF
--- a/src/android/env.rs
+++ b/src/android/env.rs
@@ -7,11 +7,7 @@ use crate::{
     os::Env as CoreEnv,
     util::cli::{Report, Reportable},
 };
-use std::{
-    collections::HashMap,
-    ffi::OsString,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, ffi::OsString, path::PathBuf};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -110,7 +106,7 @@ impl Env {
     }
 
     pub fn sdk_version(&self) -> Result<source_props::Revision, source_props::Error> {
-        SourceProps::from_path(Path::new(self.android_home()).join("tools/source.properties"))
+        SourceProps::from_path(self.platform_tools_path().join("source.properties"))
             .map(|props| props.pkg.revision)
     }
 }


### PR DESCRIPTION
Before this PR I was getting

```
[!] Android developer tools
    ✗ Failed to get SDK version: Failed to open "C:\\Users\\oli\\AppData\\Local/Android/Sdk\\tools/source.properties": Das System kann den angegebenen Pfad nicht finden. (os error 3)
    • NDK v27.1.12297006 installed at "C:\\Users\\oli\\AppData\\Local/Android/Sdk/ndk/27.1.12297006"
```

Now I get

```
[✔] Android developer tools
    • SDK v35.0.2 installed at "C:\\Users\\oli\\AppData\\Local/Android/Sdk"
    • NDK v27.1.12297006 installed at "C:\\Users\\oli\\AppData\\Local/Android/Sdk/ndk/27.1.12297006"
```