### PR TITLE
refactor: remove package and lib name validation

### DIFF
--- a/.changes/remove-name-validation.md
+++ b/.changes/remove-name-validation.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Removed name and lib name validation as they are not used as the package identifier anymore.

--- a/src/android/aab.rs
+++ b/src/android/aab.rs
@@ -79,11 +79,10 @@ pub fn build(
             Ok(())
         })
         .start()
-        .map_err(|err| {
+        .inspect_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                log::error!("`gradlew` not found. Make sure you have the Android SDK installed and added to your PATH");
             }
-            err
         })?
         .wait()?;
 

--- a/src/android/apk.rs
+++ b/src/android/apk.rs
@@ -106,11 +106,10 @@ pub fn build(
             Ok(())
         })
         .start()
-        .map_err(|err| {
+        .inspect_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                log::error!("`gradlew` not found. Make sure you have the Android SDK installed and added to your PATH");
             }
-            err
         })?
         .wait()?;
 

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -390,7 +390,7 @@ impl<'a> Device<'a> {
         let stdout = loop {
             let cmd = duct::cmd(
                 env.platform_tools_path().join("adb"),
-                ["shell", "pidof", "-s", &config.app().identifier()],
+                ["shell", "pidof", "-s", config.app().identifier()],
             )
             .vars(env.explicit_env())
             .stderr_capture()

--- a/src/apple/device/simctl/run.rs
+++ b/src/apple/device/simctl/run.rs
@@ -48,7 +48,7 @@ pub fn run(
     handle.wait().map_err(RunError::DeployFailed)?;
 
     let app_id = config.app().identifier();
-    let mut launcher_cmd = duct::cmd("xcrun", ["simctl", "launch", id, &app_id])
+    let mut launcher_cmd = duct::cmd("xcrun", ["simctl", "launch", id, app_id])
         .vars(env.explicit_env())
         .dup_stdio();
 

--- a/src/config/app/mod.rs
+++ b/src/config/app/mod.rs
@@ -93,12 +93,9 @@ impl App {
     pub fn from_raw(root_dir: PathBuf, raw: Raw) -> Result<Self, Error> {
         assert!(root_dir.is_absolute(), "root must be absolute");
 
-        let name = name::validate(raw.name).map_err(Error::NameInvalid)?;
+        let name = raw.name;
 
-        let lib_name = raw
-            .lib_name
-            .map(|n| lib_name::validate(n).map_err(Error::LibNameInvalid))
-            .transpose()?;
+        let lib_name = raw.lib_name;
 
         let stylized_name = raw.stylized_name.unwrap_or_else(|| name.clone());
 

--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -176,7 +176,7 @@ impl Raw {
 
     pub fn prompt(wrapper: &TextWrapper) -> Result<Self, PromptError> {
         let defaults = Defaults::new(wrapper).map_err(PromptError::DefaultsFailed)?;
-        let (name, default_stylized) = Self::prompt_name(wrapper, &defaults)?;
+        let (name, default_stylized) = Self::prompt_name(&defaults)?;
         let stylized_name = Self::prompt_stylized_name(&name, default_stylized)?;
         let identifier = Self::prompt_identifier(wrapper, &defaults)?;
         let template_pack = Some(Self::prompt_template_pack(wrapper)?)
@@ -193,41 +193,11 @@ impl Raw {
 }
 
 impl Raw {
-    fn prompt_name(
-        wrapper: &TextWrapper,
-        defaults: &Defaults,
-    ) -> Result<(String, Option<String>), PromptError> {
-        let mut default_name = defaults.name.clone();
-        let mut rejected = None;
-        let mut default_stylized = None;
-        let name = loop {
-            let response = prompt::default("Project name", default_name.as_deref(), None)
-                .map_err(PromptError::NamePromptFailed)?;
-            match name::validate(response.clone()) {
-                Ok(response) => {
-                    if default_name == Some(response.clone()) {
-                        if rejected.is_some() {
-                            default_stylized = rejected.take();
-                        } else {
-                            default_stylized = Some(defaults.stylized_name.clone());
-                        }
-                    }
-                    break response;
-                }
-                Err(err) => {
-                    rejected = Some(response);
-                    println!(
-                        "{}",
-                        wrapper
-                            .fill(&format!("Gosh, that's not a valid project name! {}", err))
-                            .bright_magenta()
-                    );
-                    if let Some(suggested) = err.suggested() {
-                        default_name = Some(suggested.to_owned());
-                    }
-                }
-            }
-        };
+    fn prompt_name(defaults: &Defaults) -> Result<(String, Option<String>), PromptError> {
+        let default_name = defaults.name.clone();
+        let name = prompt::default("Project name", default_name.as_deref(), None)
+            .map_err(PromptError::NamePromptFailed)?;
+        let default_stylized = Some(defaults.stylized_name.clone());
         Ok((name, default_stylized))
     }
 

--- a/src/templating/init.rs
+++ b/src/templating/init.rs
@@ -107,8 +107,8 @@ fn ident_last_part(
     _: &mut RenderContext,
     out: &mut dyn Output,
 ) -> HelperResult {
-    let last = get_str(helper).split('.').rev().next().unwrap_or_default();
-    out.write(&last).map_err(Into::into)
+    let last = get_str(helper).split('.').next_back().unwrap_or_default();
+    out.write(last).map_err(Into::into)
 }
 
 fn ident_no_last_part(


### PR DESCRIPTION
those values are not used as the identifier anymore so we do not need to validate them, deferring to the Cargo name validation is enough
