### PR TITLE
fix: removes deprecated gradle options

### DIFF
--- a/.changes/deprecated-gradle-identifiers.md
+++ b/.changes/deprecated-gradle-identifiers.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": "patch"
+---
+
+Remove deprecated options from gradle file in the generated android template.

--- a/templates/platforms/android-studio/app/build.gradle.kts.hbs
+++ b/templates/platforms/android-studio/app/build.gradle.kts.hbs
@@ -7,11 +7,11 @@ plugins {
 android {
     namespace="{{app.identifier}}"{{#if has-asset-packs}}
     assetPacks += mutableSetOf({{quote-and-join-colon-prefix asset-packs}}){{/if}}
-    compileSdk = 33
+    compileSdk = 34
     defaultConfig {
         applicationId = "{{app.identifier}}"
         minSdk = {{android.min-sdk-version}}
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
     }{{#if android-vulkan-validation}}
@@ -37,9 +37,6 @@ android {
                     .toList().toTypedArray()
             )
         }
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 }
 


### PR DESCRIPTION
fixes #392 by removing the deprecated gradle identifiers.

NB: The target SDK was also updated to 34 as this is now the minimum version for Google Play Store