### PR TITLE
feat: hyphen to underscore in default android identifier prompt

### DIFF
--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -93,7 +93,11 @@ impl Defaults {
             .to_str()
             .ok_or_else(|| DefaultsError::CurrentDirInvalidUtf8(cwd.clone()))?;
         let name = name::transliterate(&dir_name.to_kebab_case());
-        let dot_name = name.as_ref().map(|n| format!(".{n}")).unwrap_or_default();
+        let dot_name = name
+            .as_ref()
+            .map(|n| format!(".{n}"))
+            .unwrap_or_default()
+            .replace("-", "_");
         Ok(Self {
             identifier: default_identifier(wrapper, &dot_name)
                 .ok()


### PR DESCRIPTION
fixes #403 by replacing hyphens with underscores in the default android identifier