### PR TITLE
fix: missing semicolon in bevy template

### DIFF
--- a/templates/apps/bevy/src/lib.rs.hbs
+++ b/templates/apps/bevy/src/lib.rs.hbs
@@ -22,6 +22,6 @@ fn setup(
     asset_server: Res<AssetServer>,
 ) {
     let texture_handle = asset_server.load("branding/icon.png");
-    commands.spawn(Camera2dBundle::default())
+    commands.spawn(Camera2dBundle::default());
     commands.spawn(SpriteBundle {texture: texture_handle, ..Default::default()});
 }


### PR DESCRIPTION
This is essentially a final minor fix to #406 - sorry about that @amrbashir! 