### PR TITLE
Fix: Handle empty hardwareProperties JSON output from devicectl

### DIFF
--- a/.changes/fix-devicectl-list.md
+++ b/.changes/fix-devicectl-list.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Fix devicectl device list parsing when device's tunnelState is "unavailable".

--- a/src/apple/device/devicectl/device_list.rs
+++ b/src/apple/device/devicectl/device_list.rs
@@ -19,19 +19,19 @@ pub enum DeviceListError {
     InvalidDeviceList(#[from] serde_json::Error),
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceProperties {
-    name: String,
+    name: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CpuType {
     name: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HardwareProperties {
     udid: String,
@@ -40,11 +40,28 @@ pub struct HardwareProperties {
     cpu_type: CpuType,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum MaybeHardwareProperties {
+    // order matters, if we can deserialize to HardwareProperties we get Self::KnownProperties, fallback to Self::Invalid
+    KnownProperties(HardwareProperties),
+    #[allow(dead_code)]
+    Invalid(serde_json::Value),
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionProperties {
     pairing_state: String,
     tunnel_state: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaybeDeviceListDevice {
+    connection_properties: ConnectionProperties,
+    device_properties: DeviceProperties,
+    hardware_properties: MaybeHardwareProperties,
 }
 
 #[derive(Deserialize)]
@@ -57,7 +74,7 @@ pub struct DeviceListDevice {
 
 #[derive(Deserialize)]
 struct DeviceListResult {
-    devices: Vec<DeviceListDevice>,
+    devices: Vec<MaybeDeviceListDevice>,
 }
 
 #[derive(Deserialize)]
@@ -71,49 +88,39 @@ impl Reportable for DeviceListError {
     }
 }
 
-fn filter_invalid_devices(json_value: &mut serde_json::Value) {
-    if let Some(result) = json_value.get_mut("result") {
-        if let Some(devices) = result.get_mut("devices") {
-            if let Some(devices_array) = devices.as_array_mut() {
-                devices_array.retain(|device| {
-                    if let Some(hardware_props) = device.get("hardwareProperties") {
-                        !hardware_props.is_object() || !hardware_props.as_object().unwrap().is_empty()
-                    } else {
-                        false // Remove devices without hardwareProperties
-                    }
-                });
-            }
-        }
-    }
-}
-
 fn parse_device_list<'a>(json: String) -> Result<BTreeSet<Device<'a>>, DeviceListError> {
-    // First parse the JSON as a generic Value to filter out invalid devices
-    let mut json_value: serde_json::Value = serde_json::from_str(&json)
-        .map_err(|e| {
-            eprintln!("Error parsing initial JSON: {}", e);
-            DeviceListError::InvalidDeviceList(e)
-        })?;
-
-    // Filter out devices with empty hardwareProperties
-    filter_invalid_devices(&mut json_value);
-
-    // Now parse the filtered JSON in a typed way
-    let output = serde_json::from_value::<DeviceListOutput>(json_value)?;
-
-    let devices = output
+    let devices = serde_json::from_str::<DeviceListOutput>(&json)?
         .result
         .devices
         .into_iter()
-        .filter(|device| {
-            device.connection_properties.tunnel_state != "unavailable"
-                && (device.hardware_properties.platform.contains("iOS")
-                    || device.hardware_properties.platform.contains("xrOS"))
+        // early filter to not log devices with missing hardwareProperties unless they are actually in a weird/unknown state
+        .filter(|device| device.connection_properties.tunnel_state != "unavailable")
+        .filter_map(|device| {
+            if let MaybeHardwareProperties::KnownProperties(hardware_properties) =
+                device.hardware_properties
+            {
+                Some(DeviceListDevice {
+                    connection_properties: device.connection_properties,
+                    device_properties: device.device_properties,
+                    hardware_properties,
+                })
+            } else {
+                log::warn!("skipping device {:?}, unknown hardwareProperties", device);
+                None
+            }
         })
+        .filter(|device| {
+            device.hardware_properties.platform.contains("iOS")
+                || device.hardware_properties.platform.contains("xrOS")
+        })
+        .filter(|device| device.device_properties.name.is_some())
         .map(|device| {
             Device::new(
                 device.hardware_properties.udid,
-                device.device_properties.name,
+                device
+                    .device_properties
+                    .name
+                    .expect("empty device name was filtered"),
                 device.hardware_properties.product_type,
                 if device
                     .hardware_properties
@@ -153,4 +160,139 @@ pub fn device_list<'a>(env: &Env) -> Result<BTreeSet<Device<'a>>, DeviceListErro
 
     let contents = read_to_string(json_output_path_)?;
     parse_device_list(contents)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_deserialize_device_list() {
+        let json = serde_json::json!({
+            "result" : {
+                "devices" : [
+                    {
+                        "capabilities" : [
+                        {
+                            "featureIdentifier" : "com.apple.coredevice.feature.tags",
+                            "name" : "Modify Tags"
+                        }
+                        ],
+                        "connectionProperties" : {
+                        "isMobileDeviceOnly" : false,
+                        "pairingState" : "unpaired",
+                        "potentialHostnames" : [
+
+                        ],
+                        "tunnelState" : "connected"
+                        },
+                        "deviceProperties" : {
+                            "name": "Tauri iPhone",
+                            "bootState" : "booted",
+                            "ddiServicesAvailable" : false
+                        },
+                        "hardwareProperties" : {
+                            "udid": "781BF0DD-XXXXXXXXXXXXXXX",
+                            "platform": "iOS",
+                            "productType": "iOS",
+                            "cpuType": {
+                                "name": "arm64"
+                            },
+                        },
+                        "identifier" : "781BF0DD-XXXXXXXXXXXXXXX",
+                        "tags" : [],
+                    "visibilityClass" : "default"
+                    }
+                ]
+            },
+        });
+
+        let list = super::parse_device_list(serde_json::to_string(&json).unwrap())
+            .expect("can deserialize");
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn can_deserialize_empty_hardware_properties() {
+        let json = serde_json::json!({
+            "result" : {
+                "devices" : [
+                    {
+                        "capabilities" : [
+                        {
+                            "featureIdentifier" : "com.apple.coredevice.feature.tags",
+                            "name" : "Modify Tags"
+                        }
+                        ],
+                        "connectionProperties" : {
+                        "isMobileDeviceOnly" : false,
+                        "pairingState" : "unpaired",
+                        "potentialHostnames" : [
+
+                        ],
+                        "tunnelState" : "connected"
+                        },
+                        "deviceProperties" : {
+                            "name": "Tauri iPhone",
+                            "bootState" : "booted",
+                            "ddiServicesAvailable" : false
+                        },
+                        "hardwareProperties" : {
+
+                        },
+                        "identifier" : "781BF0DD-XXXXXXXXXXXXXXX",
+                        "tags" : [],
+                    "visibilityClass" : "default"
+                    }
+                ]
+            },
+        });
+
+        let list = super::parse_device_list(serde_json::to_string(&json).unwrap())
+            .expect("can deserialize");
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn filters_empty_device_name() {
+        let json = serde_json::json!({
+            "result" : {
+                "devices" : [
+                    {
+                        "capabilities" : [
+                        {
+                            "featureIdentifier" : "com.apple.coredevice.feature.tags",
+                            "name" : "Modify Tags"
+                        }
+                        ],
+                        "connectionProperties" : {
+                        "isMobileDeviceOnly" : false,
+                        "pairingState" : "unpaired",
+                        "potentialHostnames" : [
+
+                        ],
+                        "tunnelState" : "connected"
+                        },
+                        "deviceProperties" : {
+                            "bootState" : "booted",
+                            "ddiServicesAvailable" : false
+                        },
+                        "hardwareProperties" : {
+                            "udid": "781BF0DD-XXXXXXXXXXXXXXX",
+                            "platform": "iOS",
+                            "productType": "iOS",
+                            "cpuType": {
+                                "name": "arm64"
+                            },
+                        },
+                        "identifier" : "781BF0DD-XXXXXXXXXXXXXXX",
+                        "tags" : [],
+                    "visibilityClass" : "default"
+                    }
+                ]
+            },
+        });
+
+        let list = super::parse_device_list(serde_json::to_string(&json).unwrap())
+            .expect("can deserialize");
+        assert!(list.is_empty());
+    }
 }

--- a/src/apple/device/devicectl/device_list.rs
+++ b/src/apple/device/devicectl/device_list.rs
@@ -71,8 +71,37 @@ impl Reportable for DeviceListError {
     }
 }
 
+fn filter_invalid_devices(json_value: &mut serde_json::Value) {
+    if let Some(result) = json_value.get_mut("result") {
+        if let Some(devices) = result.get_mut("devices") {
+            if let Some(devices_array) = devices.as_array_mut() {
+                devices_array.retain(|device| {
+                    if let Some(hardware_props) = device.get("hardwareProperties") {
+                        !hardware_props.is_object() || !hardware_props.as_object().unwrap().is_empty()
+                    } else {
+                        false // Remove devices without hardwareProperties
+                    }
+                });
+            }
+        }
+    }
+}
+
 fn parse_device_list<'a>(json: String) -> Result<BTreeSet<Device<'a>>, DeviceListError> {
-    let devices = serde_json::from_str::<DeviceListOutput>(&json)?
+    // First parse the JSON as a generic Value to filter out invalid devices
+    let mut json_value: serde_json::Value = serde_json::from_str(&json)
+        .map_err(|e| {
+            eprintln!("Error parsing initial JSON: {}", e);
+            DeviceListError::InvalidDeviceList(e)
+        })?;
+
+    // Filter out devices with empty hardwareProperties
+    filter_invalid_devices(&mut json_value);
+
+    // Now parse the filtered JSON in a typed way
+    let output = serde_json::from_value::<DeviceListOutput>(json_value)?;
+
+    let devices = output
         .result
         .devices
         .into_iter()


### PR DESCRIPTION
The devicectl command can sometimes output what seems like invalid JSON. For example:

```
"result" : {
    "devices" : [
      {
        "capabilities" : [
          {
            "featureIdentifier" : "com.apple.coredevice.feature.tags",
            "name" : "Modify Tags"
          }
        ],
        "connectionProperties" : {
          "isMobileDeviceOnly" : false,
          "pairingState" : "unpaired",
          "potentialHostnames" : [

          ],
          "tunnelState" : "unavailable"
        },
        "deviceProperties" : {
          "bootState" : "booted",
          "ddiServicesAvailable" : false
        },
        "hardwareProperties" : {

        },
        "identifier" : "781BF0DD-XXXXXXXXXXXXXXX",
        "tags" : [

        ],
        "visibilityClass" : "default"
      },
```

Notice the empty object value for `hardwareProperties`. That caused the parse_device_list method to fail, because the JSON didn't conform to the `DeviceListOutput` type. That, in turn, caused `device_list` to return an empty list, which in turn caused `list_devices` to fall back to using `ios-deploy`, which is not compatible with iOS 16+ devices.

The fix in this commit first filters out invalid device entries before actually parsing the valid entries, thus fixing the error and the effect of incorrectly falling back to ios-deploy.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(android): fix emulator detection
    - docs: update docstrings
    - feat: add new mobile template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
