### PR TITLE
fix: iOS dev on macOS with Intel chip regression

### DIFF
--- a/.changes/fix-intel-sim-dev-regression.md
+++ b/.changes/fix-intel-sim-dev-regression.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Fix regression on development on macOS with Intel chip.

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -467,7 +467,12 @@ impl Exec for Input {
                 let simulator = arches.contains(&"Simulator".to_string());
                 let arches = if simulator {
                     // when compiling for the simulator, we don't need to build other targets
-                    vec!["arm64".to_string()]
+                    vec![if cfg!(target_arch = "aarch64") {
+                        "arm64"
+                    } else {
+                        "x86_64"
+                    }
+                    .to_string()]
                 } else {
                     arches
                 };


### PR DESCRIPTION
use the proper x86_64 simulator arch
