### PR TITLE
AndroidManifest.xml: add `screenSize|screenLayout` to `configChanges`

### DIFF
--- a/templates/platforms/android-studio/app/src/main/AndroidManifest.xml.hbs
+++ b/templates/platforms/android-studio/app/src/main/AndroidManifest.xml.hbs
@@ -4,7 +4,7 @@
     <uses-permission android:name="{{this}}" />{{/each}}{{/if}}
     <application android:hasCode="{{has-code}}" android:supportsRtl="true" android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name" android:theme="@style/AppTheme">
-        <activity android:configChanges="orientation|keyboardHidden" android:exported="true"
+        <activity android:configChanges="orientation|screenSize|screenLayout|keyboardHidden" android:exported="true"
             android:label="@string/app_name" android:name="{{android-app-activity-name}}">
             <meta-data android:name="android.app.lib_name" android:value="{{snake-case app.name}}" />
             <meta-data android:name="android.app.func_name" android:value="ANativeActivity_onCreate" />


### PR DESCRIPTION
fixes https://github.com/tauri-apps/cargo-mobile2/issues/457

As described in the linked issue, I had an application crash on rotation, that was fixed by this change.

I do think there is a second bug here, either in my own code, winit, or android-activity, which is the deadlock on app relaunch.