### PR TITLE
fix(apple): install dependencies before running iOS app

### DIFF
--- a/.changes/install-deps.md
+++ b/.changes/install-deps.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Ensure iOS dependencies ios-deploy and libimobiledevice are installed before running the app.

--- a/src/apple/deps/mod.rs
+++ b/src/apple/deps/mod.rs
@@ -18,9 +18,13 @@ use once_cell_regex::regex;
 use std::collections::hash_set::HashSet;
 use thiserror::Error;
 
+pub static IOS_DEPLOY_PACKAGE: PackageSpec = PackageSpec::brew("ios-deploy");
+pub static LIBIMOBILE_DEVICE_PACKAGE: PackageSpec =
+    PackageSpec::brew("libimobiledevice").with_bin_name("idevicesyslog");
+
 static PACKAGES: &[PackageSpec] = &[
     PackageSpec::brew("xcodegen"),
-    PackageSpec::brew("libimobiledevice").with_bin_name("idevicesyslog"),
+    LIBIMOBILE_DEVICE_PACKAGE,
     PackageSpec::brew_or_gem("cocoapods").with_bin_name("pod"),
 ];
 
@@ -130,13 +134,13 @@ fn update_package(package: &'static str, gem_cache: &mut GemCache) -> Result<(),
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum PackageSource {
     Brew,
     BrewOrGem,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct PackageSpec {
     pub pkg_name: &'static str,
     pub bin_name: &'static str,
@@ -200,7 +204,7 @@ pub fn install_all(
         package.install(reinstall_deps, &mut gem_cache)?;
     }
     if !device_ctl_available() {
-        PackageSpec::brew("ios-deploy").install(reinstall_deps, &mut gem_cache)?;
+        IOS_DEPLOY_PACKAGE.install(reinstall_deps, &mut gem_cache)?;
     }
     gem_cache.initialize()?;
     let outdated = Outdated::load(&mut gem_cache)?;

--- a/src/apple/device/devicectl/run.rs
+++ b/src/apple/device/devicectl/run.rs
@@ -1,7 +1,10 @@
 use std::{env::temp_dir, fs::read_to_string};
 
 use crate::{
-    apple::config::Config,
+    apple::{
+        config::Config,
+        deps::{GemCache, LIBIMOBILE_DEVICE_PACKAGE},
+    },
     env::{Env, ExplicitEnv as _},
     opts::NoiseLevel,
     util::cli::{Report, Reportable},
@@ -130,6 +133,10 @@ pub fn run(
             .map_err(RunError::DeployFailed)?;
 
         let app_name = config.app().stylized_name().to_string();
+
+        LIBIMOBILE_DEVICE_PACKAGE
+            .install(false, &mut GemCache::new())
+            .map_err(|e| RunError::DeployFailed(std::io::Error::other(e.to_string())))?;
 
         duct::cmd("idevicesyslog", ["--process", &app_name])
             .before_spawn(move |cmd| {

--- a/src/apple/device/ios_deploy/run.rs
+++ b/src/apple/device/ios_deploy/run.rs
@@ -1,5 +1,8 @@
 use crate::{
-    apple::config::Config,
+    apple::{
+        config::Config,
+        deps::{GemCache, IOS_DEPLOY_PACKAGE, LIBIMOBILE_DEVICE_PACKAGE},
+    },
     env::{Env, ExplicitEnv as _},
     opts::NoiseLevel,
     util::cli::{Report, Reportable},
@@ -30,6 +33,10 @@ pub fn run_and_debug(
 ) -> Result<duct::Handle, RunAndDebugError> {
     println!("Deploying app to device...");
 
+    IOS_DEPLOY_PACKAGE
+        .install(false, &mut GemCache::new())
+        .map_err(|e| RunAndDebugError::DeployFailed(std::io::Error::other(e.to_string())))?;
+
     let app_path = config.app_path();
     let deploy_cmd = duct::cmd("ios-deploy", ["--debug", "--id", id, "--no-wifi"])
         .vars(env.explicit_env())
@@ -54,6 +61,10 @@ pub fn run_and_debug(
             .map_err(RunAndDebugError::DeployFailed)?;
 
         let app_name = config.app().stylized_name().to_string();
+
+        LIBIMOBILE_DEVICE_PACKAGE
+            .install(false, &mut GemCache::new())
+            .map_err(|e| RunAndDebugError::DeployFailed(std::io::Error::other(e.to_string())))?;
 
         duct::cmd("idevicesyslog", ["--process", &app_name])
             .before_spawn(move |cmd| {

--- a/src/apple/device/mod.rs
+++ b/src/apple/device/mod.rs
@@ -1,10 +1,13 @@
 use super::{
     config::Config,
-    deps::{GemCache, PackageSpec},
+    deps::GemCache,
     target::{ArchiveError, BuildError, ExportError, Target},
 };
 use crate::{
-    apple::target::{ArchiveConfig, BuildConfig, ExportConfig},
+    apple::{
+        deps::IOS_DEPLOY_PACKAGE,
+        target::{ArchiveConfig, BuildConfig, ExportConfig},
+    },
     env::{Env, ExplicitEnv as _},
     opts,
     util::cli::{Report, Reportable},
@@ -222,7 +225,7 @@ pub fn list_devices<'a>(env: &Env) -> Result<BTreeSet<Device<'a>>, String> {
 
     // if we could not find a device with devicectl, let's use ios-deploy
     if devices.is_empty() {
-        PackageSpec::brew("ios-deploy")
+        IOS_DEPLOY_PACKAGE
             .install(false, &mut GemCache::new())
             .map_err(|e| e.to_string())?;
         return ios_deploy::device_list(env).map_err(|e| e.to_string());


### PR DESCRIPTION
currently deps are only installed on init, which might not be executed on someone's machine if the xcode project is commited to the repo. we need to ensure dependencies are installed before running them

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(android): fix emulator detection
    - docs: update docstrings
    - feat: add new mobile template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/cargo-mobile2/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
