### PR TITLE
fix(ios): Allow simulator versions newer than sdk

### DIFF
--- a/.changes/sdk-simulator-version-mismatch.md
+++ b/.changes/sdk-simulator-version-mismatch.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Allow running on simulators that have a higher version than the XCode SDK. This fixes compatiblity issues with Apple's recent `"iOS 18.5 + iOS 18.6 Simulator"` platform support component.

--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -483,11 +483,9 @@ impl<'a> Target<'a> {
             .map_err(SdkError::ParseRuntimes)?;
 
             // default SDK must be installed
-            if !available_runtimes
-                .runtimes
-                .iter()
-                .any(|runtime| runtime.version == version && runtime.is_available)
-            {
+            if !available_runtimes.runtimes.iter().any(|runtime| {
+                (runtime.version == version || *runtime.version >= *version) && runtime.is_available
+            }) {
                 log::debug!(
                     "installed runtimes: {}",
                     available_runtimes


### PR DESCRIPTION
i don't really get why i was allowed to just compare the strings like this but it actually works. Also tested the last 10 xcode sdk version strings in the rust playground and they all returns correct ordering including `15.0.1`.

that said, to be a bit safer (but also not really) we still check for equality first.