### PR TITLE
feat(apple): enhance opening Xcode

### DIFF
--- a/.changes/xcode-open.md
+++ b/.changes/xcode-open.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Enhance opening Xcode by querying the selected Xcode path with `xcode-select -p`.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -69,7 +69,10 @@ pub enum LoadOrGenError {
     #[error("Failed to load config: {0}")]
     LoadFailed(LoadError),
     #[error("Config file at {path} invalid: {cause}")]
-    FromRawFailed { path: PathBuf, cause: FromRawError },
+    FromRawFailed {
+        path: PathBuf,
+        cause: Box<FromRawError>,
+    },
     #[error(transparent)]
     GenFailed(GenError),
 }
@@ -149,7 +152,7 @@ impl Config {
                 .map(|config| (config, Origin::Loaded))
                 .map_err(|cause| LoadOrGenError::FromRawFailed {
                     path: root_dir,
-                    cause,
+                    cause: Box::new(cause),
                 })
         } else {
             Self::gen(cwd, non_interactive, wrapper)

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -107,7 +107,7 @@ pub fn open_file_with(
                 application = xcode_app_dir.to_path_buf().into_os_string();
                 log::debug!(
                     "Using Xcode app directory from `xcode-select -p`: {}",
-                    application.display()
+                    application.to_string_lossy()
                 );
             } else {
                 log::debug!(

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -1,7 +1,7 @@
 mod ffi;
 pub(super) mod info;
 
-use crate::{env::ExplicitEnv, DuctExpressionExt};
+use crate::{apple::deps::xcode_plugin::xcode_developer_dir, env::ExplicitEnv, DuctExpressionExt};
 use core_foundation::{
     array::CFArray,
     base::{OSStatus, TCFType},
@@ -87,7 +87,31 @@ pub fn open_file_with(
     path: impl AsRef<OsStr>,
     env: &Env,
 ) -> Result<(), OpenFileError> {
-    let application = application.as_ref().to_os_string();
+    let mut application = application.as_ref().to_os_string();
+
+    if application == "Xcode" {
+        if let Ok(xcode_developer_dir) = xcode_developer_dir() {
+            // xcode_developer_dir is /Applications/Xcode.app/Contents/Developer
+            // we want to open the app in /Applications/Xcode.app
+            let xcode_app_dir = xcode_developer_dir
+                .parent()
+                .and_then(|p| p.parent())
+                .unwrap_or(&xcode_developer_dir);
+            if xcode_app_dir.extension().unwrap_or_default() == "app" {
+                application = xcode_app_dir.to_path_buf().into_os_string();
+                log::debug!(
+                    "Using Xcode app directory from `xcode-select -p`: {}",
+                    application.display()
+                );
+            } else {
+                log::debug!(
+                    "Xcode directory {} from `xcode-select -p` is not a valid Xcode app path",
+                    xcode_developer_dir.display()
+                );
+            }
+        }
+    }
+
     let path = path.as_ref().to_os_string();
     duct::cmd("open", ["-a"])
         .before_spawn(move |cmd| {


### PR DESCRIPTION
detect the selected Xcode path with `xcode-select -p` so a custom Xcode path like `/Applications/Xcode-26.app` can work

closes http://github.com/tauri-apps/tauri/issues/14238
