### PR TITLE
refactor(android): include disconnected devices on adb::device_list

### DIFF
--- a/.changes/adb-list-error-refactor.md
+++ b/.changes/adb-list-error-refactor.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+Added `android::adb::device_list::Error` variants now include the serial number of the device that caused the error. 

--- a/.changes/adb-list-refactor.md
+++ b/.changes/adb-list-refactor.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": minor
+---
+
+Added `android::adb::device_list` now returns disconnected devices. Check with `android::Device::status`.

--- a/.changes/start_detached_with_options.md
+++ b/.changes/start_detached_with_options.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Added `android::Device::start_detached_with_options`.

--- a/src/android/adb/device_list.rs
+++ b/src/android/adb/device_list.rs
@@ -1,7 +1,12 @@
 use super::{device_name, get_prop};
 use crate::{
-    android::{device::Device, env::Env, target::Target},
+    android::{
+        device::{ConnectionStatus, Device},
+        env::Env,
+        target::Target,
+    },
     env::ExplicitEnv as _,
+    target::TargetTrait,
     util::cli::{Report, Reportable},
 };
 use once_cell_regex::regex_multi_line;
@@ -12,12 +17,16 @@ use thiserror::Error;
 pub enum Error {
     #[error("Failed to run `adb devices`: {0}")]
     DevicesFailed(#[from] super::RunCheckedError),
-    #[error(transparent)]
-    NameFailed(#[from] device_name::Error),
-    #[error(transparent)]
-    ModelFailed(get_prop::Error),
-    #[error(transparent)]
-    AbiFailed(get_prop::Error),
+    #[error("Failed to run `adb -s {serial_no} shell getprop ro.product.model`: {error}")]
+    ModelFailed {
+        serial_no: String,
+        error: get_prop::Error,
+    },
+    #[error("Failed to run `adb -s {serial_no} shell getprop ro.product.cpu.abi`: {error}")]
+    AbiFailed {
+        serial_no: String,
+        error: get_prop::Error,
+    },
     #[error("{0:?} isn't a valid target ABI.")]
     AbiInvalid(String),
     #[error("Failed to run {command}: {error}")]
@@ -32,8 +41,12 @@ impl Reportable for Error {
         let msg = "Failed to detect connected Android devices";
         match self {
             Self::DevicesFailed(err) => err.report("Failed to run `adb devices`"),
-            Self::NameFailed(err) => err.report(),
-            Self::ModelFailed(err) | Self::AbiFailed(err) => err.report(),
+            Self::ModelFailed { serial_no, error } | Self::AbiFailed { serial_no, error } => {
+                Report::error(
+                    format!("Failed to run `adb -s {serial_no} shell getprop`"),
+                    error,
+                )
+            }
             Self::AbiInvalid(_) => Report::error(msg, self),
             Self::CommandFailed { command, error } => {
                 Report::error(format!("Failed to run {command}"), error)
@@ -42,7 +55,7 @@ impl Reportable for Error {
     }
 }
 
-const ADB_DEVICE_REGEX: &str = r"^([\S]{6,100})	device\b";
+const ADB_DEVICE_REGEX: &str = r"^([\S]{6,100})	([\S]{6,100})\b";
 
 pub fn device_list(env: &Env) -> Result<BTreeSet<Device<'static>>, Error> {
     let mut cmd = Command::new(env.platform_tools_path().join("adb"));
@@ -56,15 +69,47 @@ pub fn device_list(env: &Env) -> Result<BTreeSet<Device<'static>>, Error> {
         regex_multi_line!(ADB_DEVICE_REGEX)
             .captures_iter(&raw_list)
             .map(|caps| {
-                assert_eq!(caps.len(), 2);
+                assert_eq!(caps.len(), 3);
                 let serial_no = caps.get(1).unwrap().as_str().to_owned();
-                let model =
-                    get_prop(env, &serial_no, "ro.product.model").map_err(Error::ModelFailed)?;
-                let name = device_name(env, &serial_no).unwrap_or_else(|_| model.clone());
-                let abi =
-                    get_prop(env, &serial_no, "ro.product.cpu.abi").map_err(Error::AbiFailed)?;
-                let target = Target::for_abi(&abi).ok_or_else(|| Error::AbiInvalid(abi.clone()))?;
-                Ok(Device::new(serial_no, name, model, target))
+                let status = caps.get(2).unwrap().as_str().to_owned();
+                let status = if status == "device" {
+                    ConnectionStatus::Connected
+                } else if status == "unauthorized" {
+                    ConnectionStatus::Unauthorized
+                } else if status == "offline" {
+                    ConnectionStatus::Offline
+                } else {
+                    log::warn!("Unknown device status {status}");
+                    ConnectionStatus::Offline
+                };
+
+                if status == ConnectionStatus::Connected {
+                    let model = get_prop(env, &serial_no, "ro.product.model").map_err(|error| {
+                        Error::ModelFailed {
+                            serial_no: serial_no.clone(),
+                            error,
+                        }
+                    })?;
+                    let name = device_name(env, &serial_no).unwrap_or_else(|_| model.clone());
+                    let abi = get_prop(env, &serial_no, "ro.product.cpu.abi").map_err(|error| {
+                        Error::AbiFailed {
+                            serial_no: serial_no.clone(),
+                            error,
+                        }
+                    })?;
+                    let target =
+                        Target::for_abi(&abi).ok_or_else(|| Error::AbiInvalid(abi.clone()))?;
+                    Ok(Device::new(serial_no, name, model, target, status))
+                } else {
+                    let name = device_name(env, &serial_no).unwrap_or_else(|_| "unknown".into());
+                    Ok(Device::new(
+                        serial_no,
+                        name,
+                        "unknown".into(),
+                        Target::all().values().next().unwrap(),
+                        status,
+                    ))
+                }
             })
             .collect()
     })

--- a/src/android/adb/device_name.rs
+++ b/src/android/adb/device_name.rs
@@ -1,3 +1,9 @@
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+    time::Duration,
+};
+
 use super::adb;
 use crate::{
     android::env::Env,
@@ -60,6 +66,14 @@ pub fn device_name(env: &Env, serial_no: &str) -> Result<String, Error> {
         .map(|stdout| stdout.split('\n').next().unwrap().trim().to_string())
         .map_err(Error::EmuFailed)?;
         if name.is_empty() {
+            if let Some(port) = serial_no
+                .strip_prefix("emulator-")
+                .and_then(|port_str| port_str.parse::<u16>().ok())
+            {
+                if let Some(name) = device_name_from_emulator_console(port) {
+                    return Ok(name);
+                }
+            }
             super::get_prop::get_prop(env, serial_no, "ro.boot.qemu.avd_name")
                 .map_err(Error::GetPropFailed)
         } else {
@@ -91,5 +105,33 @@ pub fn device_name(env: &Env, serial_no: &str) -> Result<String, Error> {
                 .map(|caps| caps["name"].to_owned())
                 .ok_or(Error::NotMatched)
         })
+    }
+}
+
+fn device_name_from_emulator_console(port: u16) -> Option<String> {
+    let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) else {
+        return None;
+    };
+
+    // short timeout so it doesn't hang
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
+
+    let _ = stream.write_all(b"avd name\n");
+    let mut buf = String::new();
+    let _ = stream.read_to_string(&mut buf);
+
+    // filter out the "OK" and "Android Console" lines
+    let name = buf
+        .lines()
+        .filter(|line| !line.contains("OK") && !line.contains("Android Console"))
+        .collect::<Vec<_>>()
+        .join("")
+        .trim()
+        .to_string();
+
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
     }
 }

--- a/src/android/cli.rs
+++ b/src/android/cli.rs
@@ -2,7 +2,7 @@ use crate::{
     android::{
         aab, adb, apk,
         config::{Config, Metadata},
-        device::{Device, RunError, StacktraceError},
+        device::{ConnectionStatus, Device, RunError, StacktraceError},
         env::{Env, Error as EnvError},
         target::{BuildError, CompileLibError, Target},
         DEFAULT_ACTIVITY, NAME,
@@ -340,7 +340,12 @@ impl Exec for Input {
                 adb::device_list(env)
                     .map_err(Error::ListFailed)
                     .map(|device_list| {
-                        prompt::list_display_only(device_list.iter(), device_list.len());
+                        prompt::list_display_only(
+                            device_list
+                                .iter()
+                                .filter(|d| d.status() == ConnectionStatus::Connected),
+                            device_list.len(),
+                        );
                     })
             }),
             Command::Apk { cmd } => match cmd {

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -117,12 +117,20 @@ impl Reportable for StacktraceError {
     }
 }
 
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
+pub enum ConnectionStatus {
+    Connected,
+    Offline,
+    Unauthorized,
+}
+
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Device<'a> {
     serial_no: String,
     name: String,
     model: String,
     target: &'a Target<'a>,
+    status: ConnectionStatus,
 }
 
 impl Display for Device<'_> {
@@ -141,12 +149,14 @@ impl<'a> Device<'a> {
         name: String,
         model: String,
         target: &'a Target<'a>,
+        status: ConnectionStatus,
     ) -> Self {
         Self {
             serial_no,
             name,
             model,
             target,
+            status,
         }
     }
 
@@ -164,6 +174,10 @@ impl<'a> Device<'a> {
 
     pub fn serial_no(&self) -> &str {
         &self.serial_no
+    }
+
+    pub fn status(&self) -> ConnectionStatus {
+        self.status
     }
 
     fn adb(&self, env: &Env) -> duct::Expression {

--- a/src/android/emulator/mod.rs
+++ b/src/android/emulator/mod.rs
@@ -28,21 +28,54 @@ impl Emulator {
         &self.name
     }
 
-    fn command(&self, env: &Env) -> duct::Expression {
+    fn command(&self, env: &Env, args: &[&str]) -> duct::Expression {
         duct::cmd(
             PathBuf::from(env.android_home()).join("emulator/emulator"),
-            ["-avd", &self.name],
+            ["-avd", &self.name, "-restart-when-stalled"]
+                .iter()
+                .chain(args),
         )
         .vars(env.explicit_env())
         .dup_stdio()
     }
 
     pub fn start(&self, env: &Env) -> Result<Handle, std::io::Error> {
-        self.command(env).start()
+        self.command(env, &[]).start()
     }
 
     pub fn start_detached(&self, env: &Env) -> Result<(), std::io::Error> {
-        self.command(env).run_and_detach()?;
+        self.command(env, &[]).run_and_detach()?;
         Ok(())
+    }
+
+    pub fn start_detached_with_options(
+        &self,
+        env: &Env,
+        options: StartOptions,
+    ) -> Result<(), std::io::Error> {
+        let mut args = Vec::new();
+        if options.full_boot {
+            args.push("-no-snapshot-load");
+        }
+        self.command(env, &args).run_and_detach()?;
+        Ok(())
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Default)]
+pub struct StartOptions {
+    full_boot: bool,
+}
+
+impl StartOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Do not auto-start from snapshot: perform a full boot
+    pub fn full_boot(mut self) -> Self {
+        self.full_boot = true;
+        self
     }
 }


### PR DESCRIPTION
follow-up for #493
this allows the Tauri CLI to detect stale emulators and restart them

since we need to match on the emulator name, i also added a new method to get the device name via the emulator console: https://developer.android.com/studio/run/emulator-console

to properly restart the emulator we need to pass `-no-snapshot-load` so that's why the new start_detached_with_options was added
