### PR TITLE
Remove once-cell-regex from dependencies

### DIFF
--- a/.changes/rm-oncecell-regex.md
+++ b/.changes/rm-oncecell-regex.md
@@ -1,0 +1,5 @@
+---
+"cargo-mobile2": patch
+---
+
+Remove unnecessary once-cell-regex dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,11 +191,12 @@ dependencies = [
  "java-properties",
  "libc",
  "log",
- "once-cell-regex",
+ "once_cell",
  "os_info",
  "os_pipe",
  "path_abs",
  "plist",
+ "regex",
  "rstest",
  "serde",
  "serde_json",
@@ -976,16 +977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "once-cell-regex"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de7e389a5043420c8f2b95ed03f3f104ad6f4c41f7d7e27298f033abc253e8"
-dependencies = [
- "once_cell",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ home = "0.5"
 ignore = "0.4"
 java-properties = "2"
 log = "0.4"
-once-cell-regex = "0.2"
+once_cell = "1.21"
+regex = "1.11"
 path_abs = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 structopt = { version = "0.3", optional = true }

--- a/src/android/adb/device_list.rs
+++ b/src/android/adb/device_list.rs
@@ -1,4 +1,5 @@
 use super::{device_name, get_prop};
+use crate::regex_multi_line;
 use crate::{
     android::{
         device::{ConnectionStatus, Device},
@@ -9,7 +10,6 @@ use crate::{
     target::TargetTrait,
     util::cli::{Report, Reportable},
 };
-use once_cell_regex::regex_multi_line;
 use std::{collections::BTreeSet, process::Command};
 use thiserror::Error;
 

--- a/src/android/adb/device_name.rs
+++ b/src/android/adb/device_name.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use super::adb;
+use crate::regex;
 use crate::{
     android::env::Env,
     util::cli::{Report, Reportable},
 };
-use once_cell_regex::regex;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/src/android/env.rs
+++ b/src/android/env.rs
@@ -7,7 +7,11 @@ use crate::{
     os::Env as CoreEnv,
     util::cli::{Report, Reportable},
 };
-use std::{collections::HashMap, ffi::OsString, path::PathBuf};
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -63,8 +67,7 @@ impl Env {
                 }
             })
             .or_else(|err| {
-                if let Some(sdk_root) = std::env::var("ANDROID_SDK_ROOT")
-                    .ok()
+                if let Some(sdk_root) = std::env::var_os("ANDROID_SDK_ROOT")
                     .map(PathBuf::from)
                     .filter(|sdk_root| sdk_root.is_dir())
                 {
@@ -75,8 +78,7 @@ impl Env {
                 }
             })
             .or_else(|err| {
-                if let Some(sdk_root) = std::env::var("ANDROID_SDK_ROOT")
-                    .ok()
+                if let Some(sdk_root) = std::env::var_os("ANDROID_SDK_ROOT")
                     .map(PathBuf::from)
                     .filter(|sdk_root| sdk_root.is_dir())
                 {
@@ -102,7 +104,7 @@ impl Env {
     }
 
     pub fn platform_tools_path(&self) -> PathBuf {
-        PathBuf::from(&self.android_home).join("platform-tools")
+        Path::new(&self.android_home).join("platform-tools")
     }
 
     pub fn sdk_version(&self) -> Result<source_props::Revision, source_props::Error> {

--- a/src/android/ndk.rs
+++ b/src/android/ndk.rs
@@ -2,6 +2,7 @@ use super::{
     source_props::{self, SourceProps},
     target::Target,
 };
+use crate::regex_multi_line;
 use crate::{
     os::consts,
     util::{
@@ -9,7 +10,6 @@ use crate::{
         VersionDouble,
     },
 };
-use once_cell_regex::regex_multi_line;
 use std::{
     collections::HashSet,
     fmt::{self, Display},

--- a/src/android/source_props.rs
+++ b/src/android/source_props.rs
@@ -1,5 +1,5 @@
+use crate::regex;
 use crate::util;
-use once_cell_regex::regex;
 use std::{
     collections::HashMap,
     fmt::Display,

--- a/src/android/target.rs
+++ b/src/android/target.rs
@@ -13,7 +13,7 @@ use crate::{
         CargoCommand,
     },
 };
-use once_cell_regex::exports::once_cell::sync::OnceCell;
+use once_cell::sync::OnceCell;
 use serde::Serialize;
 use std::{collections::BTreeMap, fmt, io, path::PathBuf, str};
 use thiserror::Error;

--- a/src/apple/deps/mod.rs
+++ b/src/apple/deps/mod.rs
@@ -6,6 +6,7 @@ use super::{
     device_ctl_available,
     system_profile::{self, DeveloperTools},
 };
+use crate::regex;
 use crate::{
     util::{
         self,
@@ -14,7 +15,6 @@ use crate::{
     },
     DuctExpressionExt,
 };
-use once_cell_regex::regex;
 use std::collections::hash_set::HashSet;
 use thiserror::Error;
 

--- a/src/apple/deps/update.rs
+++ b/src/apple/deps/update.rs
@@ -2,7 +2,7 @@ use super::{
     util::{self, CaptureGroupError},
     GemCache, PACKAGES,
 };
-use once_cell_regex::regex;
+use crate::regex;
 use serde::Deserialize;
 use thiserror::Error;
 

--- a/src/apple/project.rs
+++ b/src/apple/project.rs
@@ -1,10 +1,9 @@
-use once_cell_regex::regex;
-
 use super::{
     config::{Config, Metadata},
     deps, rust_version_check,
     target::Target,
 };
+use crate::regex;
 use crate::{
     bicycle,
     target::TargetTrait as _,

--- a/src/apple/system_profile.rs
+++ b/src/apple/system_profile.rs
@@ -1,5 +1,5 @@
+use crate::regex;
 use crate::util;
-use once_cell_regex::regex;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     DuctExpressionExt,
 };
-use once_cell_regex::exports::once_cell::sync::OnceCell;
+use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use std::{
     collections::{BTreeMap, HashMap},

--- a/src/apple/teams.rs
+++ b/src/apple/teams.rs
@@ -1,4 +1,4 @@
-use once_cell_regex::regex;
+use crate::regex;
 
 use std::collections::BTreeSet;
 use thiserror::Error;

--- a/src/config/app/mod.rs
+++ b/src/config/app/mod.rs
@@ -73,7 +73,7 @@ pub struct App {
     template_pack: Pack,
     #[serde(skip)]
     #[allow(clippy::type_complexity)]
-    target_dir_resolver: Option<Arc<Box<dyn Fn(&str, Profile) -> PathBuf>>>,
+    target_dir_resolver: Option<Arc<dyn Fn(&str, Profile) -> PathBuf>>,
 }
 
 impl Debug for App {
@@ -164,8 +164,7 @@ impl App {
         mut self,
         resolver: F,
     ) -> Self {
-        self.target_dir_resolver
-            .replace(Arc::new(Box::new(resolver)));
+        self.target_dir_resolver.replace(Arc::new(resolver));
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod doctor;
 pub mod dot_cargo;
 pub mod env;
 pub mod init;
+mod once_cell_regex;
 pub mod opts;
 pub mod os;
 mod project;

--- a/src/once_cell_regex.rs
+++ b/src/once_cell_regex.rs
@@ -1,0 +1,34 @@
+#[macro_export]
+macro_rules! regex {
+    ($re:expr) => {{
+        use ::once_cell::sync::OnceCell;
+        use ::regex::Regex;
+        static RE: OnceCell<Regex> = OnceCell::new();
+        RE.get_or_init(|| Regex::new($re).unwrap())
+    }};
+}
+
+#[macro_export]
+macro_rules! regex_multi_line {
+    ($re:expr) => {{
+        use ::once_cell::sync::OnceCell;
+        use ::regex::Regex;
+        static RE: OnceCell<Regex> = OnceCell::new();
+        RE.get_or_init(|| {
+            ::regex::RegexBuilder::new($re)
+                .multi_line(true)
+                .build()
+                .unwrap()
+        })
+    }};
+}
+
+#[macro_export]
+macro_rules! byte_regex {
+    ($re:expr) => {{
+        use ::once_cell::sync::OnceCell;
+        use ::regex::bytes::Regex;
+        static RE: OnceCell<Regex> = OnceCell::new();
+        RE.get_or_init(|| Regex::new($re).unwrap())
+    }};
+}

--- a/src/os/linux/info.rs
+++ b/src/os/linux/info.rs
@@ -1,5 +1,5 @@
 use crate::os::Info;
-use once_cell_regex::regex;
+use crate::regex;
 use std::path::PathBuf;
 use thiserror::Error;
 

--- a/src/os/linux/xdg.rs
+++ b/src/os/linux/xdg.rs
@@ -1,5 +1,6 @@
+use crate::byte_regex;
 use freedesktop_entry_parser::{parse_entry, Entry as FreeDesktopEntry};
-use once_cell_regex::{byte_regex, exports::regex::bytes::Regex};
+use regex::bytes::Regex;
 use std::{
     env,
     ffi::{OsStr, OsString},
@@ -154,8 +155,7 @@ fn parse_unquoted_text(
     // We parse the arguments
     // We only have one file path (not an URL). Any instance of these ones
     // needs to be replaced by the file path in this particular case.
-    let arg_re = byte_regex!(r"%u|%U|%f|%F");
-    let result = replace_on_pattern(text, argument, arg_re);
+    let result = replace_on_pattern(text, argument, byte_regex!(r"%u|%U|%f|%F"));
 
     // Then the other flags
     let icon_replace = icon.unwrap_or_else(|| "".as_ref());

--- a/src/os/macos/info.rs
+++ b/src/os/macos/info.rs
@@ -1,5 +1,5 @@
+use crate::regex;
 use crate::{os::Info, util};
-use once_cell_regex::regex;
 
 pub fn check() -> Result<Info, util::RunAndSearchError> {
     util::run_and_search(

--- a/src/util/cli.rs
+++ b/src/util/cli.rs
@@ -141,7 +141,7 @@ mod interface {
     use std::fmt::Debug;
 
     use crate::{opts, util};
-    use once_cell_regex::exports::once_cell::sync::Lazy;
+    use once_cell::sync::Lazy;
     use structopt::{
         clap::{self, AppSettings},
         StructOpt,

--- a/src/util/git/mod.rs
+++ b/src/util/git/mod.rs
@@ -14,21 +14,18 @@ impl<'a> Git<'a> {
         Self { root }
     }
 
-    pub fn root(&'a self) -> &'a Path {
+    pub fn root(&self) -> &Path {
         self.root
     }
 
     pub fn command(&self) -> duct::Expression {
-        duct::cmd(
-            "git",
-            ["-C", self.root.as_os_str().to_str().unwrap_or_default()],
-        )
+        duct::cmd("git", ["-C".as_ref(), self.root.as_os_str()])
     }
 
     pub fn command_parse(&self, arg_str: impl AsRef<str>) -> duct::Expression {
-        let mut args = vec!["-C", self.root.as_os_str().to_str().unwrap_or_default()];
+        let mut args = vec!["-C".as_ref(), self.root.as_os_str()];
         for arg in arg_str.as_ref().split(' ') {
-            args.push(arg)
+            args.push(arg.as_ref())
         }
         duct::cmd("git", args)
     }

--- a/src/util/git/submodule.rs
+++ b/src/util/git/submodule.rs
@@ -142,20 +142,14 @@ impl Submodule {
             cause: Box::new(Cause::IndexCheckFailed(cause)),
         })?;
         let initialized = if !in_index {
-            let path_str = self
-                .path
-                .to_str()
-                .ok_or_else(|| Error {
-                    submodule: self.clone(),
-                    cause: Box::new(Cause::PathInvalidUtf8),
-                })?
-                .to_owned();
+            let path = self.path.to_owned();
             log::info!("adding submodule: {:#?}", self);
             let remote = self.remote.clone();
             let name = name.to_owned();
             git.command()
                 .before_spawn(move |cmd| {
-                    cmd.args(["submodule", "add", "--name", &name, &remote, &path_str]);
+                    cmd.args(["submodule", "add", "--name", &name, &remote])
+                        .arg(&path);
                     Ok(())
                 })
                 .run()

--- a/src/util/git/submodule.rs
+++ b/src/util/git/submodule.rs
@@ -1,5 +1,5 @@
 use super::{lfs, Git};
-use once_cell_regex::regex;
+use crate::regex;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display},

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -29,10 +29,10 @@ use std::{
 use thiserror::Error;
 
 pub fn list_display(list: &[impl Display]) -> String {
-    if list.len() == 1 {
-        list[0].to_string()
-    } else if list.len() == 2 {
-        format!("{} and {}", list[0], list[1])
+    if let [x0] = list {
+        x0.to_string()
+    } else if let [x0, x1] = list {
+        format!("{x0} and {x1}")
     } else {
         let mut display = String::new();
         for (idx, item) in list.iter().enumerate() {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,13 +8,14 @@ pub mod prompt;
 pub use self::{cargo::*, git::*, path::*};
 
 use self::cli::{Report, Reportable};
+use crate::regex;
 use crate::{
     env::ExplicitEnv,
     os::{self, command_path},
     DuctExpressionExt,
 };
-use once_cell_regex::{exports::regex::Captures, exports::regex::Regex, regex};
 use path_abs::PathOps;
+use regex::{Captures, Regex};
 use serde::{ser::Serializer, Deserialize, Serialize};
 use std::{
     error::Error as StdError,

--- a/src/util/path.rs
+++ b/src/util/path.rs
@@ -103,9 +103,7 @@ pub fn prefix_path(root: impl AsRef<Path>, path: impl AsRef<Path>) -> PathBuf {
             }
             Component::CurDir => {}
             Component::ParentDir => {
-                if buf.last().is_some() {
-                    buf.pop();
-                }
+                buf.pop();
             }
             _ => buf.push(component),
         };


### PR DESCRIPTION
`once-cell-regex` is a tiny crate that doesn't need to be a dependency, the functions are simple enough to inline into the crate.

This is a very, very small contribution towards the auditability of Tauri, which has a lot of dependencies.